### PR TITLE
`renderTo` overwrites if the container's current `TemplateInstance` has a different `Template`.

### DIFF
--- a/src/labs/lit-extended.ts
+++ b/src/labs/lit-extended.ts
@@ -44,8 +44,10 @@ import { TemplateResult, AttributePart, TemplateInstance, TemplatePart, Part, Te
  *
  */
 export function renderExtendedTo(result: TemplateResult, container: Element|DocumentFragment) {
-  let instance = container.__templateInstance as ExtendedTemplateInstance|TemplateInstance|undefined;
-  if (instance && instance.template === result.template) {
+  let instance = container.__templateInstance as any;
+  if (instance &&
+      instance instanceof ExtendedTemplateInstance &&
+      instance.template === result.template) {
     instance.update(result.values);
     return;
   }

--- a/src/labs/lit-extended.ts
+++ b/src/labs/lit-extended.ts
@@ -44,16 +44,22 @@ import { TemplateResult, AttributePart, TemplateInstance, TemplatePart, Part, Te
  *
  */
 export function renderExtendedTo(result: TemplateResult, container: Element|DocumentFragment) {
-  let instance = container.__templateInstance as TemplateInstance;
-  if (instance === undefined) {
-    instance = new ExtendedTemplateInstance(result.template);
-    container.__templateInstance = instance;
-    const fragment = instance._clone();
+  let instance = container.__templateInstance as ExtendedTemplateInstance|TemplateInstance|undefined;
+  if (instance && instance.template === result.template) {
     instance.update(result.values);
-    container.appendChild(fragment);
-  } else {
-    instance.update(result.values);
+    return;
   }
+
+  instance = new ExtendedTemplateInstance(result.template);
+  container.__templateInstance = instance;
+
+  const fragment = instance._clone();
+  instance.update(result.values);
+
+  while (container.firstChild) {
+    container.removeChild(container.firstChild);
+  }
+  container.appendChild(fragment);
 }
 
 export class ExtendedTemplateInstance extends TemplateInstance {

--- a/src/labs/lit-extended.ts
+++ b/src/labs/lit-extended.ts
@@ -45,7 +45,7 @@ import { TemplateResult, AttributePart, TemplateInstance, TemplatePart, Part, Te
  */
 export function renderExtendedTo(result: TemplateResult, container: Element|DocumentFragment) {
   let instance = container.__templateInstance as any;
-  if (instance &&
+  if (instance !== undefined &&
       instance instanceof ExtendedTemplateInstance &&
       instance.template === result.template) {
     instance.update(result.values);

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -48,8 +48,10 @@ export class TemplateResult {
    * reevaluate the template literal and call `renderTo` of the new result.
    */
   renderTo(container: Element|DocumentFragment) {
-    let instance = container.__templateInstance as TemplateInstance|undefined;
-    if (instance && instance.template === this.template) {
+    let instance = container.__templateInstance as any;
+    if (instance &&
+        instance instanceof TemplateInstance &&
+        instance.template === this.template) {
       instance.update(this.values);
       return;
     }

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -48,16 +48,22 @@ export class TemplateResult {
    * reevaluate the template literal and call `renderTo` of the new result.
    */
   renderTo(container: Element|DocumentFragment) {
-    let instance = container.__templateInstance as TemplateInstance;
-    if (instance === undefined) {
-      instance = new TemplateInstance(this.template);
-      container.__templateInstance = instance;
-      const fragment = instance._clone();
+    let instance = container.__templateInstance as TemplateInstance|undefined;
+    if (instance && instance.template === this.template) {
       instance.update(this.values);
-      container.appendChild(fragment);
-    } else {
-      instance.update(this.values);
+      return;
     }
+
+    instance = new TemplateInstance(this.template);
+    container.__templateInstance = instance;
+
+    const fragment = instance._clone();
+    instance.update(this.values);
+
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
+    }
+    container.appendChild(fragment);
   }
 
 }
@@ -362,6 +368,10 @@ export class TemplateInstance {
 
   constructor(template: Template) {
     this._template = template;
+  }
+
+  get template() {
+    return this._template;
   }
 
   update(values: any[]) {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -49,7 +49,7 @@ export class TemplateResult {
    */
   renderTo(container: Element|DocumentFragment) {
     let instance = container.__templateInstance as any;
-    if (instance &&
+    if (instance !== undefined &&
         instance instanceof TemplateInstance &&
         instance.template === this.template) {
       instance.update(this.values);

--- a/src/test/labs/lit-extended_test.ts
+++ b/src/test/labs/lit-extended_test.ts
@@ -22,7 +22,7 @@ const assert = chai.assert;
 
 suite('lit-extended', () => {
   suite('renderExtendedTo', () => {
-    test('reuses an existing TemplateInstance when available', () => {
+    test('reuses an existing ExtendedTemplateInstance when available', () => {
         const container = document.createElement('div');
 
         const t = (content: any) => html`<div>${content}</div>`;
@@ -42,8 +42,29 @@ suite('lit-extended', () => {
         assert.equal(fooDiv, barDiv);
     });
 
-    test('overwrites an existing TemplateInstance if one exists and does ' +
-      'not have a matching Template', () => {
+    test('overwrites an existing (plain) TemplateInstance if one exists, ' +
+      'even if it has a matching Template', () => {
+        const container = document.createElement('div');
+
+        const t = () => html`<div>foo</div>`;
+
+        t().renderTo(container);
+
+        assert.equal(container.children.length, 1);
+        const firstDiv = container.children[0];
+        assert.equal(firstDiv.textContent, 'foo');
+
+        renderExtendedTo(t(), container);
+
+        assert.equal(container.children.length, 1);
+        const secondDiv = container.children[0];
+        assert.equal(secondDiv.textContent, 'foo');
+
+        assert.notEqual(firstDiv, secondDiv);
+      });
+
+    test('overwrites an existing ExtendedTemplateInstance if one exists and ' +
+      'does not have a matching Template', () => {
         const container = document.createElement('div');
 
         renderExtendedTo(html`<div>foo</div>`, container);

--- a/src/test/labs/lit-extended_test.ts
+++ b/src/test/labs/lit-extended_test.ts
@@ -25,10 +25,8 @@ suite('lit-extended', () => {
     test('reuses an existing TemplateInstance when available', () => {
       const container = document.createElement('div');
 
-      // TODO(polymerlabs/lit-html#6): These template chunks shouldn't need
-      // to have dynamic parts, but they do until #6 is fixes.
-      renderExtendedTo(html`<div>${'foo'}</div>`, container);
-      renderExtendedTo(html`<div>${'bar'}</div>`, container);
+      renderExtendedTo(html`<div>foo</div>`, container);
+      renderExtendedTo(html`<div>bar</div>`, container);
 
       assert.equal(container.children.length, 1);
       assert.equal(container.children[0].textContent, 'bar');

--- a/src/test/labs/lit-extended_test.ts
+++ b/src/test/labs/lit-extended_test.ts
@@ -23,13 +23,23 @@ const assert = chai.assert;
 suite('lit-extended', () => {
   suite('renderExtendedTo', () => {
     test('reuses an existing TemplateInstance when available', () => {
-      const container = document.createElement('div');
+        const container = document.createElement('div');
 
-      renderExtendedTo(html`<div>foo</div>`, container);
-      renderExtendedTo(html`<div>bar</div>`, container);
+        const t = (content: any) => html`<div>${content}</div>`;
 
-      assert.equal(container.children.length, 1);
-      assert.equal(container.children[0].textContent, 'bar');
+        renderExtendedTo(t('foo'), container);
+
+        assert.equal(container.children.length, 1);
+        const fooDiv = container.children[0];
+        assert.equal(fooDiv.textContent, 'foo');
+
+        renderExtendedTo(t('bar'), container);
+
+        assert.equal(container.children.length, 1);
+        const barDiv = container.children[0];
+        assert.equal(barDiv.textContent, 'bar');
+
+        assert.equal(fooDiv, barDiv);
     });
 
     test('overwrites an existing TemplateInstance if one exists and does ' +

--- a/src/test/labs/lit-extended_test.ts
+++ b/src/test/labs/lit-extended_test.ts
@@ -31,6 +31,25 @@ suite('lit-extended', () => {
       assert.equal(container.children.length, 1);
       assert.equal(container.children[0].textContent, 'bar');
     });
+
+    test('overwrites an existing TemplateInstance if one exists and does ' +
+      'not have a matching Template', () => {
+        const container = document.createElement('div');
+
+        renderExtendedTo(html`<div>foo</div>`, container);
+
+        assert.equal(container.children.length, 1);
+        const fooDiv = container.children[0];
+        assert.equal(fooDiv.textContent, 'foo');
+
+        renderExtendedTo(html`<div>bar</div>`, container);
+
+        assert.equal(container.children.length, 1);
+        const barDiv = container.children[0];
+        assert.equal(barDiv.textContent, 'bar');
+
+        assert.notEqual(fooDiv, barDiv);
+      });
   });
 });
 

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -362,6 +362,25 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, '<div>foo</div>');
       });
 
+      test('overwrites an existing TemplateInstance if one exists and does ' +
+        'not have a matching Template', () => {
+          const container = document.createElement('div');
+
+          html`<div>foo</div>`.renderTo(container);
+
+          assert.equal(container.children.length, 1);
+          const fooDiv = container.children[0];
+          assert.equal(fooDiv.textContent, 'foo');
+
+          html`<div>bar</div>`.renderTo(container);
+
+          assert.equal(container.children.length, 1);
+          const barDiv = container.children[0];
+          assert.equal(barDiv.textContent, 'bar');
+
+          assert.notEqual(fooDiv, barDiv);
+        });
+
     });
 
     suite('extensibility', () => {


### PR DESCRIPTION
Fixes #6.