### PR TITLE
Initial support for async iterables

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -350,6 +350,24 @@ export class NodePart extends Part {
         itemStart = itemEnd;
       }
       this._previousValue = itemParts;
+    } else if (value && value[Symbol.asyncIterator]) {
+      this.clear();
+      (async () => {
+        for await (const v of value) {
+          let itemStart = this.startNode;
+          if (this.startNode.nextSibling !== this.endNode) {
+            itemStart = new Text();
+            this.endNode.parentNode!.insertBefore(itemStart, this.endNode);
+          }
+          if (this._previousValue === value) {
+            const itemPart = new NodePart(this.instance, itemStart, this.endNode);
+            itemPart.setValue(v);
+          } else {
+            break;
+          }
+        }
+      })();
+      this._previousValue = value;
     } else if (this.startNode.nextSibling! === this.endNode.previousSibling! &&
         this.startNode.nextSibling!.nodeType === Node.TEXT_NODE) {
       this.startNode.nextSibling!.textContent = value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */                       
     "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     "module": "es2015",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
-    "lib": ["es2017", "dom"],                             /* Specify library files to be included in the compilation:  */
+    "lib": ["esnext", "dom"],                             /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Fixes #15 

Add support for async iterables, which can be used to stream data into a part over time.

Combined with #14 this brings the gzipped+babili size to 2k, so I do wonder if they're worth it. It is a little bit tricky to implement this inside a template function because handing races requires statefulness.