### PR TITLE
Add dirty-checking for primitive values

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -44,7 +44,7 @@ import { TemplateResult, AttributePart, TemplateInstance, TemplatePart, Part, Te
  *
  */
 export function render(result: TemplateResult, container: Element|DocumentFragment) {
-  let instance = container.__templateInstance as any;
+  let instance = (container as any).__templateInstance as any;
   if (instance !== undefined &&
       instance.template === result.template &&
       instance instanceof ExtendedTemplateInstance) {
@@ -53,7 +53,7 @@ export function render(result: TemplateResult, container: Element|DocumentFragme
   }
 
   instance = new ExtendedTemplateInstance(result.template);
-  container.__templateInstance = instance;
+  (container as any).__templateInstance = instance;
 
   const fragment = instance._clone();
   instance.update(result.values);

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -268,10 +268,32 @@ export class NodePart extends Part {
   setValue(value: any): void {
     value = this._getValue(value);
 
-    if (value instanceof Node) {
-      this._previousValue = this._setNode(value);
+    if (value === null ||
+        !(typeof value === 'object' || typeof value === 'function')) {
+      // Handle primitive values
+
+      // If the value didn't change, do nothing
+      if (value === this._previousValue) {
+        return;
+      }
+
+      if (this.startNode.nextSibling! === this.endNode.previousSibling! &&
+          this.startNode.nextSibling!.nodeType === Node.TEXT_NODE) {
+        // If we only have a single text node between the markers, we can just
+        // set its value, rather than replacing it.
+        // TODO(justinfagnani): Can we just check if _previousValue is
+        // primitive?
+        this.startNode.nextSibling!.textContent = value;
+        this._previousValue = value;
+      } else {
+        this._previousValue = this._setText(value);
+      }
     } else if (value instanceof TemplateResult) {
       this._previousValue = this._setTemplateResult(value);
+    } else if (value[Symbol.iterator]) {
+      this._previousValue = this._setIterable(value);
+    } else if (value instanceof Node) {
+      this._previousValue = this._setNode(value);
     } else if (value && value.then !== undefined) {
       value.then((v: any) => {
         if (this._previousValue === value) {
@@ -279,13 +301,8 @@ export class NodePart extends Part {
         }
       });
       this._previousValue = value;
-    } else if (value && typeof value !== 'string' && value[Symbol.iterator]) {
-      this._previousValue = this._setIterable(value);
-    } else if (this.startNode.nextSibling! === this.endNode.previousSibling! &&
-        this.startNode.nextSibling!.nodeType === Node.TEXT_NODE) {
-      this.startNode.nextSibling!.textContent = value;
-      this._previousValue = value;
     } else {
+      // Fallback, will render the string representation
       this._previousValue = this._setText(value);
     }
   }
@@ -301,13 +318,14 @@ export class NodePart extends Part {
     return value;
   }
 
-  private _setText(value: string): Node {
-    return this._setNode(new Text(value));
+  private _setText(value: string): string {
+    this._setNode(new Text(value));
+    return value;
   }
 
   private _setTemplateResult(value: TemplateResult): TemplateInstance {
     let instance: TemplateInstance;
-    if (this._previousValue && this._previousValue._template === value.template) {
+    if (this._previousValue && this._previousValue.template === value.template) {
       instance = this._previousValue;
     } else {
       instance = this.instance._createInstance(value.template);
@@ -393,17 +411,13 @@ export class NodePart extends Part {
 }
 
 export class TemplateInstance {
-  _template: Template;
   _parts: Part[] = [];
+  template: Template;
   startNode: Node;
   endNode: Node;
 
   constructor(template: Template) {
-    this._template = template;
-  }
-
-  get template() {
-    return this._template;
+    this.template = template;
   }
 
   update(values: any[]) {
@@ -419,12 +433,12 @@ export class TemplateInstance {
   }
 
   _clone(): DocumentFragment {
-    const fragment = document.importNode(this._template.element.content, true);
+    const fragment = document.importNode(this.template.element.content, true);
 
-    if (this._template.parts.length > 0) {
+    if (this.template.parts.length > 0) {
       const walker = document.createTreeWalker(fragment, 5 /* elements & text */);
 
-      const parts = this._template.parts;
+      const parts = this.template.parts;
       let index = 0;
       let partIndex = 0;
       let templatePart = parts[0];

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -288,6 +288,33 @@ suite('lit-html', () => {
 
     suite('update', () => {
 
+      test('dirty checks simple values', () => {
+        const container = document.createElement('div');
+        let foo = 'aaa';
+
+        const t = () => html`<div>${foo}</div>`;
+
+        render(t(), container);
+        assert.equal(container.innerHTML, '<div>aaa</div>');
+        const text = container.firstChild!.childNodes[2] as Text;
+        assert.equal(text.textContent, 'aaa');
+
+        // Set textContent manually. Since lit-html doesn't dirty checks against
+        // actual DOM, but again previous part values, this modification should
+        // persist through the next render with the same value.
+        text.textContent = 'bbb';
+        assert.equal(text.textContent, 'bbb');
+        assert.equal(container.innerHTML, '<div>bbb</div>');
+
+        // Re-render with the same content, should be a no-op
+        render(t(), container);
+        assert.equal(container.innerHTML, '<div>bbb</div>');
+        const text2 = container.firstChild!.childNodes[2] as Text;
+
+        // The next node should be the same too
+        assert.strictEqual(text, text2);
+      });
+
       test('renders to and updates a container', () => {
         const container = document.createElement('div');
         let foo = 'aaa';
@@ -696,7 +723,7 @@ suite('lit-html', () => {
         part.setValue(r);
         assert.equal(container.innerHTML, '<h1>bar</h1>');
         const newH1 = container.querySelector('h1');
-        assert.isTrue(newH1 === originalH1);
+        assert.strictEqual(newH1, originalH1);
       });
 
       test('updates are stable when called multiple times with arrays of templates', () => {


### PR DESCRIPTION
Seems to give a ~5% improvement on first render, and ~25% improvement on updates for a deep recursion benchmark.