### PR TITLE
Fix until test

### DIFF
--- a/src/test/lib/until_test.ts
+++ b/src/test/lib/until_test.ts
@@ -30,6 +30,7 @@ suite('until', () => {
     assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
     resolve!('foo');
     await promise;
+    await new Promise((r) => setTimeout(() => r()));
     assert.equal(container.innerHTML, '<div>foo</div>');         
   });
 


### PR DESCRIPTION
For some reason the until test was failing on Chrome, but only when devtools were closed :/ It was passing fine on Safari and Firefox.

Waiting one event loop turn fixed it.