### PR TITLE
Simplify the handling of Arrays and Iterables

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -706,6 +706,17 @@ suite('lit-html', () => {
         assert.strictEqual(container.lastChild, endNode);
       });
 
+      test('updates arrays with siblings', () => {
+        let items = [1, 2, 3];
+        const t = () => html`<p></p>${items}<a></a>`;
+
+        render(t(), container);
+        assert.equal(container.innerHTML, '<p></p>123<a></a>');
+
+        items = [1, 2, 3, 4];
+        render(t(), container);
+        assert.equal(container.innerHTML, '<p></p>1234<a></a>');
+      });
 
       test('updates are stable when called multiple times with templates', () => {
         let value = 'foo';


### PR DESCRIPTION
This isn't a big performance improvement, but it really simplifies handling of iterables, using a for/of loop, rather than manually using the JS iteration protocol.

It should also make Array handling more easily backward compatible with IE11. We just need an Array.isArray() polyfill, and either just the existence of `Symbol` or an extra guard in case `Symbol` doesn't exist.