### PR TITLE
Refactor node finding to use DFS instead of TreeWalker.

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -56,11 +56,11 @@ suite('lit-html', () => {
       const result = html`
         <div a="${1}">
           <p>${2}</p>
-          ${3}
-          <span a="${4}">${5}</span>
+          ${3}x${4}
+          <span a="${5}x${6}">${7}x${8}</span>
         </div>`;
       const parts = result.template.parts;
-      assert.equal(parts.length, 5);
+      assert.equal(parts.length, 7);
     });
 
     test('stores raw names of attributes', () => {


### PR DESCRIPTION
This is a somewhat speculative PR. It's performance neutral in a couple of microbenchmarks I'm trying out, but those microbenchmarks are pretty bad. It _should_ be perf positive with larger templates.

This is one optimization I mentioned in #9. An alternative is to not use cloning for template instantiation, but walk the template, appending into the container, finding parts, and inserting values in one pass. Ideally we'd try both, with some more realistic benchmarks, before committing, but considering that this one is at worst perf-neutral, and opens up the door to more easily fixing #45 it might be worthwhile to commit this anyway.

This does add ~100 bytes to the minified+gziped output size, at 1880b, putting us pretty close to 2kb 🤔

Edit: A couple of situations where this should clearly visit less nodes than TreeWalker:
- Static subtrees will be skipped, since no path terminates in them
- An element with a node binding as the first child can skip traversing the rest of its children