### PR TITLE
Add SVG support & demo

### DIFF
--- a/demo/clock.html
+++ b/demo/clock.html
@@ -1,0 +1,19 @@
+
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+  <head>
+    <script type="module" src="./clock.js"></script>
+  </head>
+  <body>
+    <lit-clock></lit-clock>
+  </body>
+</html>

--- a/demo/clock.js
+++ b/demo/clock.js
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+
+import {html, render, svg} from '../lit-html.js';
+
+/** 
+ * Adapted from the Ractive.js clock example: http://www.ractivejs.org/examples/clock/
+ */
+export class LitClock extends HTMLElement {
+
+  get date() { return this._date; }
+  set date(v) { this._date = v; this.invalidate(); }
+
+  constructor() {
+    super();
+    this.attachShadow({mode: 'open'});
+    setInterval(() => {
+      this.date = new Date();
+    }, 1000);
+  }
+
+  render() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+        .square {
+          position: relative;
+          width: 100%;
+          height: 0;
+          padding-bottom: 100%;
+        }
+        
+        svg {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+        }
+        
+        .clock-face {
+          stroke: #333;
+          fill: white;
+        }
+        
+        .minor {
+          stroke: #999;
+          stroke-width: 0.5;
+        }
+        
+        .major {
+          stroke: #333;
+          stroke-width: 1;
+        }
+        
+        .hour {
+          stroke: #333;
+        }
+        
+        .minute {
+          stroke: #666;
+        }
+        
+        .second, .second-counterweight {
+          stroke: rgb(180,0,0);
+        }
+        
+        .second-counterweight {
+          stroke-width: 3;
+        }
+      </style>
+      <div class='square'> <!-- so the SVG keeps its aspect ratio -->
+        
+        <svg viewBox='0 0 100 100'>
+          
+          <!-- first create a group and move it to 50,50 so
+              all co-ords are relative to the center -->
+          <g transform='translate(50,50)'>
+            <circle class='clock-face' r='48'/>
+            ${minuteTicks}
+            ${hourTicks}
+    
+            <!-- hour hand -->
+            <line class='hour' y1='2' y2='-20'
+              transform='rotate(${ 30 * this.date.getHours() + this.date.getMinutes() / 2 })'/>
+    
+            <!-- minute hand -->
+            <line class='minute' y1='4' y2='-30'
+              transform='rotate(${ 6 * this.date.getMinutes() + this.date.getSeconds() / 10 })'/>
+    
+            <!-- second hand -->
+            <g transform='rotate(${ 6 * this.date.getSeconds() })'>
+              <line class='second' y1='10' y2='-38'/>
+              <line class='second-counterweight' y1='10' y2='2'/>
+            </g>
+          </g>
+        </svg>
+      </div>
+    `;
+  }
+
+  invalidate() {
+    if (!this.needsRender) {
+      this.needsRender = true;
+      Promise.resolve().then(() => {
+        this.needsRender = false;
+        render(this.render(), this.shadowRoot);
+      });
+    }
+  }
+}
+customElements.define('lit-clock', LitClock);
+
+const minuteTicks = (() => {
+  const lines = [];
+  for (let i = 0; i < 60; i++) {
+    lines.push(svg`
+      <line 
+        class='minor'
+        y1='42'
+        y2='45'
+        transform='rotate(${360 * i / 60})'/>
+    `);
+  }
+  return lines;
+})();
+
+const hourTicks = (() => {
+  const lines = [];
+  for (let i = 0; i < 12; i++) {
+    lines.push(svg`
+      <line 
+        class='major'
+        y1='32'
+        y2='45'
+        transform='rotate(${360 * i / 12})'/>
+    `);
+  }
+  return lines;
+})();

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -16,16 +16,30 @@
 // calls to a tag for the same literal, so we can cache work done per literal
 // in a Map.
 const templates = new Map<TemplateStringsArray, Template>();
+const svgTemplates = new Map<TemplateStringsArray, Template>();
 
 /**
  * Interprets a template literal as an HTML template that can efficiently
  * render to and update a container.
  */
-export function html(
-    strings: TemplateStringsArray, ...values: any[]): TemplateResult {
+export const html = (strings: TemplateStringsArray, ...values: any[]) =>
+    litTag(strings, values, templates, false);
+
+/**
+ * Interprets a template literal as an SVG template that can efficiently
+ * render to and update a container.
+ */
+export const svg = (strings: TemplateStringsArray, ...values: any[]) =>
+    litTag(strings, values, svgTemplates, true);
+
+function litTag(
+    strings: TemplateStringsArray,
+    values: any[],
+    templates: Map<TemplateStringsArray, Template>,
+    isSvg: boolean): TemplateResult {
   let template = templates.get(strings);
   if (template === undefined) {
-    template = new Template(strings);
+    template = new Template(strings, isSvg);
     templates.set(strings, template);
   }
   return new TemplateResult(template, values);
@@ -110,10 +124,12 @@ export class TemplatePart {
 export class Template {
   parts: TemplatePart[] = [];
   element: HTMLTemplateElement;
+  svg: boolean;
 
-  constructor(strings: TemplateStringsArray) {
+  constructor(strings: TemplateStringsArray, svg: boolean = false) {
+    this.svg = svg;
     this.element = document.createElement('template');
-    this.element.innerHTML = strings.join(exprMarker);
+    this.element.innerHTML = this._getHtml(strings, svg);
     const walker = document.createTreeWalker(
         this.element.content, 5 /* elements & text */);
     let index = -1;
@@ -177,6 +193,14 @@ export class Template {
     for (const n of nodesToRemove) {
       n.parentNode!.removeChild(n);
     }
+  }
+
+  /**
+   * Returns a string of HTML used to create a <template> element.
+   */
+  private _getHtml(strings: TemplateStringsArray, svg?: boolean): string {
+    const html = strings.join(exprMarker);
+    return svg ? `<svg>${html}</svg>` : html;
   }
 }
 
@@ -465,6 +489,14 @@ export class TemplateInstance {
           index++;
           node = walker.nextNode();
         }
+      }
+    }
+    if (this.template.svg) {
+      const svgElement = fragment.firstChild!;
+      fragment.removeChild(svgElement);
+      const nodes = svgElement.childNodes;
+      for (let i = 0; i < nodes.length; i++) {
+        fragment.appendChild(nodes.item(i));
       }
     }
     return fragment;

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -15,7 +15,7 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 
-import {AttributePart, defaultPartCallback, html, NodePart, Part, render, TemplateInstance, TemplatePart, TemplateResult} from '../lit-html.js';
+import {AttributePart, defaultPartCallback, html, NodePart, Part, render, svg, TemplateInstance, TemplatePart, TemplateResult} from '../lit-html.js';
 
 const assert = chai.assert;
 
@@ -320,6 +320,15 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, `<div foo="bar">
               baz
               <p>qux</p></div>`);
+      });
+
+      test('renders SVG', () => {
+        const container = document.createElement('svg');
+        const t = svg`<line y1="1" y2="1"/>`;
+        render(t, container);
+        const line = container.firstElementChild!;
+        assert.equal(line.tagName, 'line');
+        assert.equal(line.namespaceURI, 'http://www.w3.org/2000/svg');
       });
 
     });


### PR DESCRIPTION
Adds a new `svg` template tag, so you can declare that templates should produce nodes in the SVG namespace:

```javascript
html`
  <svg>
    <circle/>
    ${data.map(d => svg`<line ... />`)}
  </svg>
`
```