### PR TITLE
Fix for `{{}}` in the template.

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -77,7 +77,7 @@ export function render(result: TemplateResult, container: Element|DocumentFragme
 
 /** Unique key to avoid https://github.com/PolymerLabs/lit-html/issues/62 */
 const markerID = Math.random();
-const exprMarker = '{{' + markerID + '}}';
+const exprMarker = `{{${markerID}}}`;
 
 /**
  * A placeholder for a dynamic expression in an HTML template.

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -75,7 +75,9 @@ export function render(result: TemplateResult, container: Element|DocumentFragme
   container.appendChild(fragment);
 }
 
-const exprMarker = '{{}}';
+/** Unique key to avoid https://github.com/PolymerLabs/lit-html/issues/62 */
+const markerID = Math.random();
+const exprMarker = '{{' + markerID + '}}';
 
 /**
  * A placeholder for a dynamic expression in an HTML template.

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -75,9 +75,11 @@ export function render(result: TemplateResult, container: Element|DocumentFragme
   container.appendChild(fragment);
 }
 
-/** Unique key to avoid https://github.com/PolymerLabs/lit-html/issues/62 */
-const markerID = Math.random();
-const exprMarker = `{{${markerID}}}`;
+/** 
+ * An expression marker with embedded unique key to avoid 
+ * https://github.com/PolymerLabs/lit-html/issues/62
+ */
+const exprMarker = `{{lit-${Math.random()}}}`;
 
 /**
  * A placeholder for a dynamic expression in an HTML template.

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -52,6 +52,15 @@ suite('lit-html', () => {
       assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 3);
     });
 
+    test('escapes marker sequences in text nodes', () => {
+      const container = document.createElement('div');
+      const result = html`{{}}`;
+      assert.equal(result.template.parts.length, 0);
+      render(result, container);
+      console.log(container.innerHTML);
+      assert.equal(container.innerHTML, '{{}}');
+    });
+
     test('parses parts for multiple expressions', () => {
       const result = html`
         <div a="${1}">


### PR DESCRIPTION
Suggested fix for https://github.com/PolymerLabs/lit-html/issues/62

The value of `exprMarker` becomes a magic string that breaks any template that includes it. To avoid that added a random number that changes when the file is reloaded (there are probably better ways to do that though).