### PR TITLE
feat(tsconfig): inlineSources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2017", "dom"],
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "./",
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,


### PR DESCRIPTION

> Emit the source alongside the sourcemaps within a single file; requires `--inlineSourceMap` or `--sourceMap` to be set.

https://www.typescriptlang.org/docs/handbook/compiler-options.html