### PR TITLE
Initialize NodePart._previousValue to undefined

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -261,6 +261,7 @@ export class NodePart implements SinglePart {
     this.instance = instance;
     this.startNode = startNode;
     this.endNode = endNode;
+    this._previousValue = undefined;
   }
 
   setValue(value: any): void {


### PR DESCRIPTION
Avoid adding new properties to NodePart post construction, makes closure compiler a bit more happy as well.