### PR TITLE
Add a failing swap test

### DIFF
--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -62,6 +62,24 @@ suite('repeat', () => {
       assert.strictEqual(children1[2], children2[0]);
     });
 
+    test('swaps are stable', () => {
+      const t = (items: number[]) =>
+          html`${repeat(items, (i) => i, (i: number) => html`
+          <li>item: ${i}</li>`)}`;
+
+      render(t([1, 2, 3, 4, 5]), container);
+
+      assert.equal(
+          container.innerHTML,
+          [1, 2, 3, 4, 5].map(i => `<li>item: ${i}</li>`).join(''))
+
+      render(t([1, 5, 3, 4, 2]), container);
+
+      assert.equal(
+          container.innerHTML,
+          [1, 5, 3, 4, 2].map(i => `<li>item: ${i}</li>`).join(''))
+    });
+
     test('can insert an item at the beginning', () => {
       let items = [1, 2, 3];
       const t = () =>

--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -80,6 +80,26 @@ suite('repeat', () => {
           [1, 5, 3, 4, 2].map(i => `<li>item: ${i}</li>`).join(''))
     });
 
+    test('can re-render after swap', () => {
+      const t = (items: number[]) =>
+          html`${repeat(items, (i) => i, (i: number) => html`
+          <li>item: ${i}</li>`)}`;
+
+      render(t([1, 2, 3]), container);
+
+      assert.equal(
+          container.innerHTML,
+          [1, 2, 3].map(i => `<li>item: ${i}</li>`).join(''))
+
+      render(t([3, 2, 1]), container);
+
+      assert.equal(
+          container.innerHTML,
+          [3, 2, 1].map(i => `<li>item: ${i}</li>`).join(''))
+
+      render(t([3, 2, 1]), container);
+    })
+
     test('can insert an item at the beginning', () => {
       let items = [1, 2, 3];
       const t = () =>


### PR DESCRIPTION
This failing test was discovered by
https://github.com/sunesimonsen/lit-html-tests/blob/master/test/repeat.spec.js#L12

I first saw the problem when playing with a web component example where I was swapping colors randomly:

![swap](https://user-images.githubusercontent.com/90802/32125208-19f44e02-bb6b-11e7-9d3c-fc4895372689.gif) 