### PR TITLE
Support for Edge/IE11

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -144,7 +144,7 @@ export class Template {
     this.element = document.createElement('template');
     this.element.innerHTML = this._getHtml(strings, svg);
     const walker = document.createTreeWalker(
-        this.element.content, 5 /* elements & text */);
+        this.element.content, 5 /* elements & text */, undefined, false);
     let index = -1;
     let partIndex = 0;
     const nodesToRemove = [];
@@ -192,7 +192,7 @@ export class Template {
           // Generate a new text node for each literal section
           // These nodes are also used as the markers for node parts
           for (let i = 0; i < lastIndex; i++) {
-            parent.insertBefore(new Text(strings[i]), node);
+            parent.insertBefore(document.createTextNode(strings[i]), node);
             this.parts.push(new TemplatePart('node', index++));
           }
         } else if (!node.nodeValue!.trim()) {
@@ -346,7 +346,7 @@ export class NodePart implements SinglePart {
       // primitive?
       node.textContent = value;
     } else {
-      this._setNode(new Text(value));
+      this._setNode(document.createTextNode(value));
     }
     this._previousValue = value;
   }
@@ -400,7 +400,7 @@ export class NodePart implements SinglePart {
         // node, and fix up the previous part's endNode to point to it
         if (partIndex > 0) {
           const previousPart = itemParts[partIndex - 1];
-          itemStart = previousPart.endNode = new Text();
+          itemStart = previousPart.endNode = document.createTextNode('');
           this._insert(itemStart);
         }
         itemPart = new NodePart(this.instance, itemStart, this.endNode);
@@ -488,7 +488,7 @@ export class TemplateInstance {
 
     if (this.template.parts.length > 0) {
       const walker =
-          document.createTreeWalker(fragment, 5 /* elements & text */);
+          document.createTreeWalker(fragment, 5 /* elements & text */, undefined, false);
 
       const parts = this.template.parts;
       let index = 0;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -145,7 +145,7 @@ export class Template {
     this.element.innerHTML = this._getHtml(strings, svg);
     // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
     const walker = document.createTreeWalker(
-        this.element.content, 5 /* elements & text */, (<any>null), false);
+        this.element.content, 5 /* elements & text */, null as any, false);
     let index = -1;
     let partIndex = 0;
     const nodesToRemove = [];
@@ -347,7 +347,7 @@ export class NodePart implements SinglePart {
       // primitive?
       node.textContent = value;
     } else {
-      this._setNode(document.createTextNode(value));
+      this._setNode(document.createTextNode(value === undefined ? '' : value));
     }
     this._previousValue = value;
   }
@@ -490,7 +490,7 @@ export class TemplateInstance {
     if (this.template.parts.length > 0) {
       // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
       const walker =
-          document.createTreeWalker(fragment, 5 /* elements & text */, (<any>null), false);
+          document.createTreeWalker(fragment, 5 /* elements & text */, null as any, false);
 
       const parts = this.template.parts;
       let index = 0;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -143,8 +143,9 @@ export class Template {
     this.svg = svg;
     this.element = document.createElement('template');
     this.element.innerHTML = this._getHtml(strings, svg);
+    // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
     const walker = document.createTreeWalker(
-        this.element.content, 5 /* elements & text */, undefined, false);
+        this.element.content, 5 /* elements & text */, (<any>null), false);
     let index = -1;
     let partIndex = 0;
     const nodesToRemove = [];
@@ -487,8 +488,9 @@ export class TemplateInstance {
     const fragment = document.importNode(this.template.element.content, true);
 
     if (this.template.parts.length > 0) {
+      // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
       const walker =
-          document.createTreeWalker(fragment, 5 /* elements & text */, undefined, false);
+          document.createTreeWalker(fragment, 5 /* elements & text */, (<any>null), false);
 
       const parts = this.template.parts;
       let index = 0;


### PR DESCRIPTION
just a small thing to support EDGE (tested on "Edge 40; EdgeHTML 15").

IE11 apparently renders the html but won't insert the values - needs some more investigation
=> maybe another PR if I can figure it out

@justinfagnani sooo this actually also work in IE11 :)
2 Limitations so far:
1) Last node can't be a node with a variable
```
// => works in IE11
return html`
	<h2>${header}</h2>
	<p>ending</p>
`;

// does not work in IE11
return html`
	<h2>${header}</h2>
`;
````
2) You need a polyfill for template tag and ES6 Symbols
=> so this should be somewhere noted

I will copy this to an Issue