### PR TITLE
Edge unit tests pass

### DIFF
--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -77,10 +77,10 @@ export function repeat<T>(
       if (itemPart === undefined) {
         // New part, attach it
         if (currentMarker === undefined) {
-          currentMarker = new Text();
+          currentMarker = document.createTextNode('');
           container.insertBefore(currentMarker, part.startNode.nextSibling);
         }
-        const endNode = new Text();
+        const endNode = document.createTextNode('');
         container.insertBefore(endNode, currentMarker.nextSibling);
         itemPart = new NodePart(part.instance, currentMarker, endNode);
         if (key !== undefined && keyMap !== undefined) {
@@ -105,7 +105,7 @@ export function repeat<T>(
             const contents = range.extractContents();
             if (part.startNode.nextSibling === part.endNode) {
               // The container part was empty, so we need a new endPart
-              itemPart.endNode = new Text();
+              itemPart.endNode = document.createTextNode('');
               container.insertBefore(
                   itemPart.endNode, part.startNode.nextSibling);
             } else {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -248,7 +248,7 @@ export class Template {
         // placholder, or empty text, add a marker node.
         if (node.previousSibling === null ||
             node.previousSibling !== previousNode) {
-          parent.insertBefore(new Text(), node);
+          parent.insertBefore(document.createTextNode(''), node);
         } else {
           index--;
         }
@@ -258,7 +258,7 @@ export class Template {
         // We don't have to check if the next node is going to be removed,
         // because that node will induce a marker if so.
         if (node.nextSibling === null) {
-          parent.insertBefore(new Text(), node);
+          parent.insertBefore(document.createTextNode(''), node);
         } else {
           index--;
         }

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -188,7 +188,7 @@ export class Template {
         // attributes are not guaranteed to be returned in document order. In
         // particular, Edge/IE can return them out of order, so we cannot assume
         // a correspondance between part index and attribute index.
-        
+
         // Do a first pass to count attributes that correspond to parts.
         const attributesWithParts: string[][] = [].filter.call(attributes, (attribute: Attr) =>
           attribute.value.split(attrOrTextRegex).length > 1

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -184,24 +184,30 @@ export class Template {
           continue;
         }
         const attributes = node.attributes;
-        for (let i = 0; i < attributes.length; i++) {
-          const attribute = attributes.item(i);
-          const attributeStrings = attribute.value.split(attrOrTextRegex);
-          if (attributeStrings.length > 1) {
-            // Get the template literal section leading up to the first
-            // expression in this attribute attribute
-            const attributeString = strings[partIndex];
-            // Trim the trailing literal value if this is an interpolation
-            const rawNameString = attributeString.substring(
-                0, attributeString.length - attributeStrings[0].length);
-            // Find the attribute name
-            const rawName = rawNameString.match(/((?:\w|[.\-_$])+)=["']?$/)![1];
-            this.parts.push(new TemplatePart(
-                'attribute', index, attribute.name, rawName, attributeStrings));
-            node.removeAttribute(attribute.name);
-            partIndex += attributeStrings.length - 1;
-            i--;
-          }
+        // Per https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap,
+        // attributes are not guaranteed to be returned in document order. In
+        // particular, Edge/IE can return them out of order, so we cannot assume
+        // a correspondance between part index and attribute index.
+        
+        // Do a first pass to count attributes that correspond to parts.
+        const attributesWithParts: string[][] = [].filter.call(attributes, (attribute: Attr) =>
+          attribute.value.split(attrOrTextRegex).length > 1
+        );
+        // Loop that many times, but don't use loop index for anything.
+        for (let i = 0; i < attributesWithParts.length; i++) {
+          // Get the template literal section leading up to the first
+          // expression in this attribute attribute
+          const stringForPart = strings[partIndex];
+          // Find the attribute name
+          // Trim the trailing literal value if this is an interpolation
+          const attributeNameInPart = stringForPart.match(/((?:\w|[.\-_$])+)=["']?/)![1];
+          // Find the corresponding attribute
+          const attribute = attributes.getNamedItem(attributeNameInPart);
+          const stringsForAttributeValue = attribute.value.split(attrOrTextRegex);
+          this.parts.push(new TemplatePart(
+            'attribute', index, attribute.name, attributeNameInPart, stringsForAttributeValue));
+          node.removeAttribute(attribute.name);
+          partIndex += stringsForAttributeValue.length - 1;
         }
       } else if (node.nodeType === 3 /* Node.TEXT_NODE */) {
         const nodeValue = node.nodeValue!;

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -528,7 +528,7 @@ suite('lit-html', () => {
         render(t(), container);
         assert.equal(container.innerHTML, '<div><div></div></div>');
 
-        child = new Text('foo');
+        child = document.createTextNode('foo');
         render(t(), container);
         assert.equal(container.innerHTML, '<div>foo<div></div></div>');
       });
@@ -548,7 +548,7 @@ suite('lit-html', () => {
         render(t(), container);
         assert.equal(container.innerHTML, '<div></div>');
 
-        children = new Text('foo');
+        children = document.createTextNode('foo');
         render(t(), container);
         assert.equal(container.innerHTML, '<div>foo</div>');
       });
@@ -648,8 +648,8 @@ suite('lit-html', () => {
 
     setup(() => {
       container = document.createElement('div');
-      startNode = new Text();
-      endNode = new Text();
+      startNode = document.createTextNode('');
+      endNode = document.createTextNode('');
       container.appendChild(startNode);
       container.appendChild(endNode);
       const instance = new TemplateInstance(html``.template);
@@ -884,7 +884,7 @@ suite('lit-html', () => {
       });
 
       test('clears a range', () => {
-        container.insertBefore(new Text('foo'), endNode);
+        container.insertBefore(document.createTextNode('foo'), endNode);
         part.clear();
         assert.deepEqual(
             Array.from(container.childNodes), [startNode, endNode]);


### PR DESCRIPTION
This is a partial fix for #111 for Microsoft Edge. It fixes the 48 unit tests which were broken on Edge so that all 96 tests now pass.

_This still relies on native ES modules_, which must be enabled on Edge through about:flags, "Enable experimental JavaScript features". This PR just fixes the unit tests. To get everything to pass in production Edge (and, eventually, IE), separate work will be required to create a bundled build.

One thing to review: the loop that processed attributes needed to be rewritten to deal with the fact that Edge and IE don't necessarily return attributes in document order. The new loop extracts the expected string name for the attribute from the corresponding member of `strings`, then uses that to look up the actual `Attr` instance on the element. Because of that change in sequence, the relevant regex `match` call had to be updated: rather than matching against the entire string, the `$` (match end of string) directive was dropped. This still appears to find the attribute name correctly, at least as far as evidenced in the unit tests.