### PR TITLE
Add a failing nested templates test

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -490,7 +490,7 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, '<h2>bar</h2>baz');
       });
 
-      test('updates nested templates with elements', () => {
+      test('updates nested templates with preceding elements', () => {
         let foo = 'foo';
         const bar = 'bar';
         const baz = 'baz';

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -490,6 +490,33 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, '<h2>bar</h2>baz');
       });
 
+      test('updates nested templates with elements', () => {
+        let foo = 'foo';
+        const bar = 'bar';
+        const baz = 'baz';
+
+        const t = (x: boolean) => {
+          let partial;
+          if (x) {
+            partial = html`<h1>${foo}</h1>`;
+          } else {
+            partial = html`<h2>${bar}</h2>`;
+          }
+
+          return html`<a>${baz}</a>${partial}`;
+        };
+
+        render(t(true), container);
+        assert.equal(container.innerHTML, '<a>baz</a><h1>foo</h1>');
+
+        foo = 'bbb';
+        render(t(true), container);
+        assert.equal(container.innerHTML, '<a>baz</a><h1>bbb</h1>');
+
+        render(t(false), container);
+        assert.equal(container.innerHTML, '<a>baz</a><h2>bar</h2>');
+      });
+
       test('updates arrays', () => {
         let items = [1, 2, 3];
         const t = () => html`<div>${items}</div>`;


### PR DESCRIPTION
Test rendering nested templates when parent template contains preceding nodes, such as:
```js
html`<a>${foo}</a>${partial}`
```

Currently, lit-html throws `Cannot read property 'parentNode' of null` when trying to render such templates.