### PR TITLE
fix(IE11): manually create empty text nodes => 60 passing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "wct-browser-legacy": "^0.0.1-pre.10",
     "web-component-tester": "^6.3.0",
     "@webcomponents/template": "^1.1.0",
-    "get-own-property-symbols": "^0.9.2"
+    "babel-polyfill": "^6.26.0"
   },
   "typings": "lit-html.d.ts",
   "dependencies": {}

--- a/test/index.html
+++ b/test/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/get-own-property-symbols/build/get-own-property-symbols.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>
     <script type="module" src="./lit-html_test.js"></script>


### PR DESCRIPTION
Finally found a better approach to bring IE11 on board. Still not perfect but it's 60 passing tests and the basic functionality is working :)

```
// from
Test Results
57 failing tests
39 passing tests
// to
Test Results
36 failing tests
60 passing tests
```

especially with Sub Templates there is still something going on...