### PR TITLE
Optimizes Template#_getHtml

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -296,7 +296,7 @@ export class Template {
   private _getHtml(strings: TemplateStringsArray, svg?: boolean): string {
     const l = strings.length;
     let html = '';
-    let isTextBinding = false;
+    let isTextBinding = true;
     for (let i = 0; i < l - 1; i++) {
       const s = strings[i];
       html += s;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -111,20 +111,24 @@ export function render(
  */
 const attributeMarker = `{{lit-${Math.random()}}}`;
 
-/**
- * Regex to scan the string preceding an expression to see if we're in a text
- * context, and not an attribute context.
- *
- * This works by seeing if we have a `>` not followed by a `<`. If there is a
- * `<` closer to the end of the strings, then we're inside a tag.
- */
-const textRegex = />[^<]*$/;
-const hasTagsRegex = /[^<]*/;
 const textMarkerContent = '_-lit-html-_';
 const textMarker = `<!--${textMarkerContent}-->`;
 const attrOrTextRegex = new RegExp(`${attributeMarker}|${textMarker}`);
 const lastAttributeNameRegex =
     /((?:\w|[.\-_$])+)=(?:[^"']*|(?:["][^"]*)|(?:['][^']*))$/;
+
+/**
+ * Finds the closing index of the last closed HTML tag.
+ * This has 3 possible return values:
+ *   - `-1`, meaning there is no tag in str.
+ *   - `string.length`, meaning the last opened tag is unclosed.
+ *   - Some positive number < str.length, meaning the index of the closing '>'.
+ */
+function findTagClose(str: string) : number {
+  const close = str.lastIndexOf('>');
+  const open = str.indexOf('<', close + 1);
+  return open > -1 ? str.length : close;
+}
 
 /**
  * A placeholder for a dynamic expression in an HTML template.
@@ -291,20 +295,19 @@ export class Template {
    */
   private _getHtml(strings: TemplateStringsArray, svg?: boolean): string {
     const l = strings.length;
-    const a = [];
+    let html = '';
     let isTextBinding = false;
     for (let i = 0; i < l - 1; i++) {
       const s = strings[i];
-      a.push(s);
-      // We're in a text position if the previous string matches the
-      // textRegex. If it doesn't and the previous string has no tags, then
-      // we use the previous text position state.
-      isTextBinding = s.match(textRegex) !== null ||
-          (s.match(hasTagsRegex) !== null && isTextBinding);
-      a.push(isTextBinding ? textMarker : attributeMarker);
+      html += s;
+      // We're in a text position if the previous string closed its tags.
+      // If it doesn't have any tags, then we use the previous text position
+      // state.
+      const closing = findTagClose(s);
+      isTextBinding = closing > -1 ? closing < s.length : isTextBinding;
+      html += isTextBinding ? textMarker : attributeMarker;
     }
-    a.push(strings[l - 1]);
-    const html = a.join('');
+    html += strings[l - 1];
     return svg ? `<svg>${html}</svg>` : html;
   }
 }

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -94,13 +94,25 @@ suite('lit-html', () => {
           ['someProp', 'a-nother', 'multiParts', undefined, 'aThing']);
     });
 
+    test('parses element-less text expression', () => {
+      const container = document.createElement('div');
+      const result = html`<div>${1} ${2}</div>`;
+      render(result, container);
+      assert.equal(container.innerHTML, '<div>1 2</div>');
+    });
+
+    test('parses expressions for two child nodes of one element', () => {
+      const container = document.createElement('div');
+      const result = html`test`;
+      render(result, container);
+      assert.equal(container.innerHTML, 'test');
+    });
+
     test('parses expressions for two attributes of one element', () => {
+      const container = document.createElement('div');
       const result = html`<div a="${1}" b="${2}"></div>`;
-      const parts = result.template.parts;
-      assert.equal(parts.length, 2);
-      const instance = new TemplateInstance(result.template);
-      instance._clone();
-      assert.equal(instance._parts.length, 2);
+      render(result, container);
+      assert.equal(container.innerHTML, '<div a="1" b="2"></div>');
     });
 
     test('updates when called multiple times with arrays', () => {


### PR DESCRIPTION
Two main optimizations:

1. The regexs are _really_ bad at predicting where the end of a string
is. This leads to bad performance when using a `*` quantifier to match
everything to the end. It's much faster to use `#indexOf` and
`#lastIndexOf` to find the `<` and `>`, and do some comparisons.
   - https://jsperf.com/html-template-tag-context

2. String concatenation is much faster than building an array to join
it.
   - https://jsperf.com/string-concatenation/47
     - (This even compares an already made array, it's super slow without
   even building the array in a loop!)