### PR TITLE
Optimize repeat

### DIFF
--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -43,112 +43,65 @@ export function repeat<T>(
     let state = stateCache.get(part);
     if (state === undefined) {
       state = {
-        keyMap: keyFn && new Map(),
+        keyMap: new Map(),
         parts: [],
       };
       stateCache.set(part, state);
     }
     const container = part.startNode.parentNode as HTMLElement | ShadowRoot |
         DocumentFragment;
-    const oldParts = state.parts;
-    const endParts = new Map<Node, NodePart>(
-        oldParts.map((p) => [p.endNode, p] as [Node, NodePart]));
     const keyMap = state.keyMap;
 
     const itemParts = [];
-    let index = 0;
-    let currentMarker: Node|undefined;
+    let index = -1;
+    let currentMarker = part.startNode.nextSibling;
 
     for (const item of items) {
       let result;
       let key;
       try {
-        result = template !(item, index++);
-        key = keyFn && keyFn(item);
+        ++index;
+        result = template!(item, index);
+        key = keyFn ? keyFn(item) : index;
       } catch (e) {
         console.error(e);
         continue;
       }
 
-      // Try to reuse a part, either keyed or from the list of previous parts
-      // if there's no keyMap
-      let itemPart = keyMap === undefined ? oldParts[0] : keyMap.get(key);
+      // Try to reuse a part
+      let itemPart = keyMap.get(key);
 
       if (itemPart === undefined) {
-        // New part, attach it
-        if (currentMarker === undefined) {
-          currentMarker = document.createTextNode('');
-          container.insertBefore(currentMarker, part.startNode.nextSibling);
-        }
+        const marker = document.createTextNode('');
         const endNode = document.createTextNode('');
-        container.insertBefore(endNode, currentMarker.nextSibling);
-        itemPart = new NodePart(part.instance, currentMarker, endNode);
-        if (key !== undefined && keyMap !== undefined) {
-          keyMap.set(key, itemPart!);
+        container.insertBefore(marker, currentMarker);
+        container.insertBefore(endNode, currentMarker);
+        itemPart = new NodePart(part.instance, marker, endNode);
+        if (key !== undefined) {
+          keyMap.set(key, itemPart);
         }
-      } else {
-        // Existing part, maybe move it
+      } else if (currentMarker !== itemPart.startNode) {
+        // Existing part in the wrong position
         const range = document.createRange();
         range.setStartBefore(itemPart.startNode);
-        range.setEndBefore(itemPart.endNode);
-
-        if (currentMarker === undefined) {
-          // this should be the first part, make sure it's first
-          if (part.startNode.nextSibling !== itemPart.startNode) {
-            // move the whole part
-            // get previous and next parts
-            const previousPart = endParts.get(itemPart.startNode);
-            if (previousPart) {
-              previousPart.endNode = itemPart.endNode;
-              endParts.set(previousPart.endNode, previousPart);
-            }
-            const contents = range.extractContents();
-            if (part.startNode.nextSibling === part.endNode) {
-              // The container part was empty, so we need a new endPart
-              itemPart.endNode = document.createTextNode('');
-              container.insertBefore(
-                  itemPart.endNode, part.startNode.nextSibling);
-            } else {
-              // endNode should equal the startNode of the currently first part
-              itemPart.endNode = part.startNode.nextSibling!;
-            }
-            container.insertBefore(contents, part.startNode.nextSibling);
-          }
-          // else part is in the correct position already
-        } else if (currentMarker !== itemPart.startNode) {
-          // move to correct position
-          const previousPart = endParts.get(itemPart.startNode);
-          if (previousPart) {
-            previousPart.endNode = itemPart.endNode;
-            endParts.set(previousPart.endNode, previousPart);
-          }
-          const contents = range.extractContents();
-          container.insertBefore(contents, currentMarker);
-        }
-
-        // remove part from oldParts list so it's not cleaned up
-        oldParts.splice(oldParts.indexOf(itemPart), 1);
+        range.setEndAfter(itemPart.endNode);
+        const contents = range.extractContents();
+        container.insertBefore(contents, currentMarker);
+      } else {
+        // else part is in the correct position already
+        currentMarker = itemPart.endNode.nextSibling;
       }
-      // else part is in the correct position already
 
       itemPart.setValue(result);
       itemParts.push(itemPart);
-      currentMarker = itemPart.endNode;
     }
 
     // Cleanup
-    if (oldParts.length > 0) {
-      const clearStart = oldParts[0].startNode;
-      const clearEnd = oldParts[oldParts.length - 1].endNode;
-      const clearRange = document.createRange();
-      if (itemParts.length === 0) {
-        clearRange.setStartBefore(clearStart);
-      } else {
-        clearRange.setStartAfter(clearStart);
-      }
-      clearRange.setEndAfter(clearEnd);
-      clearRange.deleteContents();
-      clearRange.detach();  // is this neccessary?
+    if (currentMarker !== part.endNode) {
+      const range = document.createRange();
+      range.setStartBefore(currentMarker!);
+      range.setEndBefore(part.endNode);
+      range.deleteContents();
     }
 
     state.parts = itemParts;

--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -24,6 +24,12 @@ interface State {
 
 const stateCache = new WeakMap<NodePart, State>();
 
+function cleanMap(part: NodePart, key: any, map: Map<any, NodePart>) {
+  if (!part.startNode.parentNode) {
+    map.delete(key);
+  }
+}
+
 export function repeat<T>(
     items: T[], keyFn: KeyFn<T>, template: ItemTemplate<T>): DirectiveFn;
 export function repeat<T>(items: T[], template: ItemTemplate<T>): DirectiveFn;
@@ -102,6 +108,7 @@ export function repeat<T>(
       range.setStartBefore(currentMarker!);
       range.setEndBefore(part.endNode);
       range.deleteContents();
+      keyMap.forEach(cleanMap);
     }
 
     state.parts = itemParts;


### PR DESCRIPTION
This pretty seriously optimizes the repeat directive.

Now, it creates an extra text node for every item (it creates an explicit start node for every item, instead of reusing the previous' end node). That's not _perfect_, but it simplifies a lot of code and makes it run _much_ faster. I think it's a pretty good tradeoff.

Fixes #95.
Fixes #157.