### PR TITLE
Minor fix NodePart#_setPromise

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -517,13 +517,13 @@ export class NodePart implements SinglePart {
     }
   }
 
-  protected _setPromise(value: Promise<any>): void {
+  private _setPromise(value: Promise<any>): void {
+    this._previousValue = value;
     value.then((v: any) => {
       if (this._previousValue === value) {
         this.setValue(v);
       }
     });
-    this._previousValue = value;
   }
 
   clear(startNode: Node = this.startNode) {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -368,6 +368,16 @@ suite('lit-html', () => {
         });
       });
 
+      test('renders a sync thenable', () => {
+        const promise = {
+          then(cb: (foo: string) => void) {
+            cb('foo');
+          }
+        };
+        render(html`<div>${promise}</div>`, container);
+        assert.equal(container.innerHTML, '<div>foo</div>');
+      });
+
       test('renders racing Promises correctly', () => {
         let resolve1: (v: any) => void;
         const promise1 = new Promise((res, _) => {


### PR DESCRIPTION
Not all thenables behave asynchronously, so we should set the
`#_previousValue` first. And, it should be private like all the other
helper methods on `NodePart`.