### PR TITLE
Simplify EventPart

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -107,22 +107,17 @@ export class EventPart implements Part {
 
   setValue(value: any): void {
     const listener = getValue(this, value);
-    if (listener === this._listener) {
+    const previous = this._listener;
+    if (listener === previous) {
       return;
     }
-    if (listener == null) {
-      this.element.removeEventListener(this.eventName, this);
-    } else if (this._listener == null) {
-      this.element.addEventListener(this.eventName, this);
-    }
-    this._listener = listener;
-  }
 
-  handleEvent(event: Event) {
-    if (typeof this._listener === 'function') {
-      this._listener.call(this.element, event);
-    } else if (typeof this._listener.handleEvent === 'function') {
-      this._listener.handleEvent(event);
+    this._listener = listener;
+    if (previous != null) {
+      this.element.removeEventListener(this.eventName, previous);
+    }
+    if (listener != null) {
+      this.element.addEventListener(this.eventName, listener);
     }
   }
 }

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -143,10 +143,13 @@ suite('lit-extended', () => {
       const listener = () => {
         count++;
       };
+      const wrapped = listener;
       const go = () =>
-          render(html`<div on-click=${listener}></div>`, container);
+          render(html`<div on-click=${wrapped}></div>`, container);
       go();
       go();
+
+      wrapped = () => listener();
       go();
       const div = container.firstChild as HTMLElement;
       div.click();

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -138,22 +138,35 @@ suite('lit-extended', () => {
       assert.equal(thisValue, listener);
     });
 
-    test('only adds event listeners once', () => {
+    test('only adds event listener once', () => {
       let count = 0;
       const listener = () => {
         count++;
       };
-      const wrapped = listener;
-      const go = () =>
-          render(html`<div on-click=${wrapped}></div>`, container);
-      go();
-      go();
+      render(html`<div on-click=${listener}></div>`, container);
+      render(html`<div on-click=${listener}></div>`, container);
 
-      wrapped = () => listener();
-      go();
       const div = container.firstChild as HTMLElement;
       div.click();
       assert.equal(count, 1);
+    });
+
+    test('allows updating event listener', () => {
+      let count1 = 0;
+      const listener1 = () => {
+        count1++;
+      };
+      let count2 = 0;
+      const listener2 = () => {
+        count2++;
+      };
+      render(html`<div on-click=${listener1}></div>`, container);
+      render(html`<div on-click=${listener2}></div>`, container);
+
+      const div = container.firstChild as HTMLElement;
+      div.click();
+      assert.equal(count1, 0);
+      assert.equal(count2, 1);
     });
 
     test('removes event listeners', () => {


### PR DESCRIPTION
No need to register the part as a listener, just register the listener.

And fixes bugs with updating the event listener (instead of having to render it null first).