### PR TITLE
Record NodePart's endNode index during cloning

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -54,6 +54,9 @@ suite('lit-html', () => {
       assert.equal(countNodes(html`${0}b${0}`, (c) => c.childNodes), 3);
       assert.equal(countNodes(html`${0}${0}c`, (c) => c.childNodes), 3);
       assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 3);
+
+      assert.equal(countNodes(html`<a></a>${0}`, (c) => c.childNodes), 2);
+      assert.equal(countNodes(html`${0}<a></a>`, (c) => c.childNodes), 2);
     });
 
     test('escapes marker sequences in text nodes', () => {


### PR DESCRIPTION
This fixes the issue with `<a>some child</a>${expression}` attachment.
Since the traversal order is 0: `<a>`, 1: `"some child"`, 2:
`<!--marker-->`, we would find the marker and incorrectly record 2 as its location.
But 2 is inside the `<a>` tag, that's no good. This is because we assumed the index
was the previous sibling, but it can actually be the last child of a deep descendant of
the previous node.

Fixes #148.