### PR TITLE
Repeat duplicate

### DIFF
--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -116,6 +116,14 @@ suite('repeat', () => {
       render(t([3, 2, 1]), container);
     });
 
+    test('can render repeated items', () => {
+      const t = (items: number[]) =>
+          html`${repeat(items, (i) => i, (i: number) => html`
+          <li>item: ${i}</li>`)}`;
+
+      render(t([666, 666]), container);
+    })
+
     test('can insert an item at the beginning', () => {
       let items = [1, 2, 3];
       const t = () =>


### PR DESCRIPTION
Also optimizes for Object keys, in which case we can use a `WeakMap`,
and skip map cleanups.

Fixes #173.