### PR TITLE
Optimize lastAttributeNameRegex

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -134,10 +134,10 @@ const nonWhitespace = /[^\s]/;
  *  * Followed by:
  *    * Any character except space, ('), ("), "<", ">", "=", or
  *    * (") then any non-("), or
- *    * (') then any non-(')
+ *    * (') then lastAttributeNameRegexany non-(')
  */
-const lastAttributeNameRegex =
-    /([^\0-\x1F\x7F-\x9F \x09\x0a\x0c\x0d"'>=/]+)[ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*)$/;
+const  =
+    /[ \x09\x0a\x0c\x0d]([^\0-\x1F\x7F-\x9F \x09\x0a\x0c\x0d"'>=/]+)[ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*)$/;
 
 /**
  * Finds the closing index of the last closed HTML tag.

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -132,7 +132,7 @@ const nonWhitespace = /[^\s]/;
  *  * Followed by "="
  *  * Followed by zero or more space characters
  *  * Followed by:
- *    * Any character except space, ('), ("), "<", ">", "=", or
+ *    * Any character except space, ('), ("), "<", ">", "=", (`), or
  *    * (") then any non-("), or
  *    * (') then any non-(')
  */

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -134,9 +134,9 @@ const nonWhitespace = /[^\s]/;
  *  * Followed by:
  *    * Any character except space, ('), ("), "<", ">", "=", or
  *    * (") then any non-("), or
- *    * (') then lastAttributeNameRegexany non-(')
+ *    * (') then any non-(')
  */
-const  =
+const lastAttributeNameRegex =
     /[ \x09\x0a\x0c\x0d]([^\0-\x1F\x7F-\x9F \x09\x0a\x0c\x0d"'>=/]+)[ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*)$/;
 
 /**


### PR DESCRIPTION
A pretty easy optimization to `lastAttributeNameRegex`. Giving it a starting bound improves the performance by 2-3x in Chrome, 3x in Safari, and 5-6x in Firefox.

See https://regex101.com/r/etquoe/2/, and try deleting the space character class at the beginning, and see the match time in the upper right side of the input.

Then try this [very long attribute name](https://regex101.com/r/etquoe/3) on on for size. It's infinitely faster (division by zero error...). And then there's improvement to super long [quoted](https://regex101.com/r/etquoe/4) and [unquoted](https://regex101.com/r/etquoe/6) attribute values.

The space between a tagname and an attribute, or between two attributes, is required by https://www.w3.org/TR/html5/syntax.html#attributes-0.