### PR TITLE
Leave whitespace text nodes intact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6272,6 +6272,12 @@
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6282,12 +6288,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -36,8 +36,10 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
       render(r, container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
     });
 
     test('renders a list twice', () => {
@@ -47,13 +49,17 @@ suite('repeat', () => {
 
       render(t([1, 2, 3]), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
 
       render(t([1, 2, 3]), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
     });
 
     test('shuffles are stable', () => {
@@ -63,15 +69,19 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
       const children1 = Array.from(container.querySelectorAll('li'));
 
       items = [3, 2, 1];
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 3<!----></li><li>item: 2<!----></li><li>item: 1<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 3<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 1<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[2]);
       assert.strictEqual(children1[1], children2[1]);
@@ -81,37 +91,49 @@ suite('repeat', () => {
     test('swaps are stable', () => {
       const t = (items: number[]) =>
           html`${repeat(items, (i) => i, (i: number) => html`
-          <li>item: ${i}</li>`)}`;
+            <li>item: ${i}</li>`)}`;
 
       render(t([1, 2, 3, 4, 5]), container);
 
       assert.equal(
-          container.innerHTML,
-          `<!---->${[1, 2, 3, 4, 5].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li>
+            <li>item: 4<!----></li>
+            <li>item: 5<!----></li><!---->`);
 
       render(t([1, 5, 3, 4, 2]), container);
 
       assert.equal(
-          container.innerHTML,
-          `<!---->${[1, 5, 3, 4, 2].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 5<!----></li>
+            <li>item: 3<!----></li>
+            <li>item: 4<!----></li>
+            <li>item: 2<!----></li><!---->`);
     });
 
     test('can re-render after swap', () => {
       const t = (items: number[]) =>
           html`${repeat(items, (i) => i, (i: number) => html`
-          <li>item: ${i}</li>`)}`;
+            <li>item: ${i}</li>`)}`;
 
       render(t([1, 2, 3]), container);
 
       assert.equal(
-          container.innerHTML,
-          `<!---->${[1, 2, 3].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
 
       render(t([3, 2, 1]), container);
 
       assert.equal(
-          container.innerHTML,
-          `<!---->${[3, 2, 1].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 3<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 1<!----></li><!---->`);
 
       render(t([3, 2, 1]), container);
     });
@@ -119,30 +141,34 @@ suite('repeat', () => {
     test('can render repeated items', () => {
       const t = (items: number[]) =>
           html`${repeat(items, (i) => i, (i: number) => html`
-          <li>item: ${i}</li>`)}`;
+            <li>item: ${i}</li>`)}`;
 
       render(t([666, 666]), container);
-      assert.equal(container.innerHTML, `<!----><li>item: 666<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 666<!----></li><!---->`);
     });
 
     test('can render repeated items with skip', () => {
       const t = (items: number[]) =>
           html`${repeat(items, (i) => i, (i: number) => html`
-          <li>item: ${i}</li>`)}`;
+            <li>item: ${i}</li>`)}`;
 
       render(t([666, 777, 666]), container);
-      assert.equal(container.innerHTML, `<!----><li>item: 777<!----></li><li>item: 666<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 777<!----></li>
+            <li>item: 666<!----></li><!---->`);
     });
 
     test('can rerender repeated items', () => {
       let updates = 0;
       const t = (items: number[]) =>
           html`${repeat(items, (i) => i, () => html`
-          <li>item: ${++updates}</li>`)}`;
+            <li>item: ${++updates}</li>`)}`;
 
       render(t([666, 666]), container);
       assert.equal(updates, 2);
-      assert.equal(container.innerHTML, `<!----><li>item: 2<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 2<!----></li><!---->`);
     });
 
     test('can insert an item at the beginning', () => {
@@ -155,8 +181,11 @@ suite('repeat', () => {
       items = [0, 1, 2, 3];
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 0<!----></li><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 0<!----></li>
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
     });
 
     test('can insert an item at the end', () => {
@@ -169,8 +198,11 @@ suite('repeat', () => {
       items = [1, 2, 3, 4];
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><li>item: 4<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li>
+            <li>item: 4<!----></li><!---->`);
     });
 
     test('can replace with an empty list', () => {
@@ -196,7 +228,9 @@ suite('repeat', () => {
 
       items = [2, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `<!----><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[1], children2[0]);
       assert.strictEqual(children1[2], children2[1]);
@@ -213,7 +247,9 @@ suite('repeat', () => {
 
       items = [1, 2];
       render(t(), container);
-      assert.equal(container.innerHTML, `<!----><li>item: 1<!----></li><li>item: 2<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[0]);
       assert.strictEqual(children1[1], children2[1]);
@@ -230,7 +266,9 @@ suite('repeat', () => {
 
       items = [1, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `<!----><li>item: 1<!----></li><li>item: 3<!----></li><!---->`);
+      assert.equal(container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 3<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[0]);
       assert.strictEqual(children1[2], children2[1]);
@@ -245,8 +283,10 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
       render(r, container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
     });
 
     test('shuffles a list', () => {
@@ -255,14 +295,18 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li><!---->`);
 
       items = [3, 2, 1];
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 3<!----></li><li>item: 2<!----></li><li>item: 1<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 3<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 1<!----></li><!---->`);
     });
 
     test('can replace with an empty list', () => {
@@ -284,8 +328,12 @@ suite('repeat', () => {
       render(t(), container);
       render(t(), container);
       assert.equal(
-          container.innerHTML,
-          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><li>item: 4<!----></li><li>item: 5<!----></li><!---->`);
+          container.innerHTML, `<!---->
+            <li>item: 1<!----></li>
+            <li>item: 2<!----></li>
+            <li>item: 3<!----></li>
+            <li>item: 4<!----></li>
+            <li>item: 5<!----></li><!---->`);
     });
   });
 });

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -172,11 +172,6 @@ suite('lit-html', () => {
         container = document.createElement('div');
       });
 
-      test('removes whitespace-only nodes', () => {
-        render(html`<div>  </div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
-      });
-
       test('renders a string', () => {
         render(html`<div>${'foo'}</div>`, container);
         assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
@@ -363,7 +358,10 @@ suite('lit-html', () => {
           <div>${''}</div>
           <div foo=${'bar'}></div>
         `, container);
-        assert.equal(container.innerHTML, '<div><!----><!----></div><div foo="bar"></div>');
+        assert.equal(container.innerHTML, `
+          <div><!----><!----></div>
+          <div foo="bar"></div>
+        `);
       });
 
       test('renders to attributes with attribute-like values', () => {
@@ -468,11 +466,14 @@ suite('lit-html', () => {
             </style>
             <a href="/buy/${'foo'}"></a>
           `, container);
-        assert.equal(container.innerHTML, `<style>
+        assert.equal(container.innerHTML, `
+            <style>
               .foo {
                 background: black;
               }
-            </style><a href="/buy/foo"></a>`);
+            </style>
+            <a href="/buy/foo"></a>
+          `);
       });
 
       test('renders a combination of stuff', () => {
@@ -481,9 +482,11 @@ suite('lit-html', () => {
               ${'baz'}
               <p>${'qux'}</p>
             </div>`, container);
-        assert.equal(container.innerHTML, `<div foo="bar">
+        assert.equal(container.innerHTML, `
+            <div foo="bar">
               baz
-              <p><!---->qux<!----></p></div>`);
+              <p><!---->qux<!----></p>
+            </div>`);
       });
 
       test('renders SVG', () => {
@@ -501,11 +504,14 @@ suite('lit-html', () => {
             <!-- this is a comment -->
             <h1 class="${'foo'}">title</h1>
             <p>${'foo'}</p>
-            </div>`;
+          </div>`;
         render(t, container);
-        assert.equal(container.innerHTML, `<div>
+        assert.equal(container.innerHTML, `
+          <div>
             <!-- this is a comment -->
-            <h1 class="foo">title</h1><p><!---->foo<!----></p></div>`);
+            <h1 class="foo">title</h1>
+            <p><!---->foo<!----></p>
+          </div>`);
       });
 
       test('renders expressions with preceding elements', () => {


### PR DESCRIPTION
Our whitespace stripper doesn't understand CSS's whitespace collapsing rules. For instsance,

```js
html`<span>test<span> <a href="">ing</a>`
```

should read "test ing".