### PR TITLE
Add prepare script to allow linking or github installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "quicktest": "wct -l chrome -p --npm",
     "checksize": "uglifyjs lit-html.js -mc --toplevel | gzip -9 | wc -c",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
-    "lint": "tslint --project ./"
+    "lint": "tslint --project ./",
+    "prepare": "npm run build"
   },
   "author": "The Polymer Authors",
   "devDependencies": {


### PR DESCRIPTION
The prepare script is run after installation and before publish, meaning that
it is run during npm-link and when installing from the github repository,
e.g. when fetching a prereleased version.

This means we can use

```json
{
  "//": "...",
  "devDependencies": {
    "lit-html": "PolymerLabs/lit-html#master",
  }
}
```

and it'll work, rather than leave us with a package containing the typescript sources but no build output.