### PR TITLE
Failing test for re-rendering repeated items containing duplicates

### DIFF
--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -145,6 +145,19 @@ suite('repeat', () => {
       assert.equal(container.innerHTML, `<li>item: 2</li>`);
     });
 
+    test('can rerender repeated items with no changes', () => {
+      const t = (items: number[]) =>
+          html`${repeat(items, (i) => i, (i: number) => html`
+          <li>item: ${i}</li>`)}`;
+
+      render(t([666, 666]), container);
+      render(t([666, 666]), container);
+
+      assert.equal(
+          container.innerHTML,
+          `<li>item: 666</li><li>item: 666</li>`);
+    })
+
     test('can insert an item at the beginning', () => {
       let items = [1, 2, 3];
       const t = () =>


### PR DESCRIPTION
I ran [my property based test](https://github.com/sunesimonsen/lit-html-tests/blob/master/test/repeat.spec.js#L38) on the latest master and got this result:

<img width="520" alt="screen shot 2017-11-14 at 19 49 46" src="https://user-images.githubusercontent.com/90802/32798469-17641632-c975-11e7-818e-5ad2074fc027.png">

This PR adds a failing test for the found case.
