### PR TITLE
Do not use empty text nodes in the template element

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -260,12 +260,12 @@ export class Template {
           // We keep this current node, but reset its content to the last
           // literal part. We insert new literal nodes before this so that the
           // tree walker keeps its position correctly.
-          node.textContent = strings[lastIndex];
+          node.textContent = strings[lastIndex] || marker;
 
           // Generate a new text node for each literal section
           // These nodes are also used as the markers for node parts
           for (let i = 0; i < lastIndex; i++) {
-            parent.insertBefore(document.createTextNode(strings[i]), node);
+            parent.insertBefore(document.createTextNode(strings[i] || marker), node);
             this.parts.push(new TemplatePart('node', index++));
           }
         } else {
@@ -300,7 +300,7 @@ export class Template {
         const previousSibling = node.previousSibling;
         if (previousSibling === null || previousSibling !== previousNode ||
             previousSibling.nodeType !== Node.TEXT_NODE) {
-          parent.insertBefore(document.createTextNode(''), node);
+          parent.insertBefore(document.createTextNode(marker), node);
         } else {
           index--;
         }
@@ -310,7 +310,7 @@ export class Template {
         // We don't have to check if the next node is going to be removed,
         // because that node will induce a new marker if so.
         if (node.nextSibling === null) {
-          parent.insertBefore(document.createTextNode(''), node);
+          parent.insertBefore(document.createTextNode(marker), node);
         } else {
           index--;
         }
@@ -432,6 +432,15 @@ export class NodePart implements SinglePart {
     this.instance = instance;
     this.startNode = startNode;
     this.endNode = endNode;
+
+    if (startNode.nodeValue === marker) {
+      startNode.nodeValue = '';
+    }
+
+    if (endNode.nodeValue === marker) {
+      endNode.nodeValue = '';
+    }
+
     this._previousValue = undefined;
   }
 

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -257,17 +257,24 @@ export class Template {
           // We have a part for each match found
           partIndex += lastIndex;
 
-          // We keep this current node, but reset its content to the last
-          // literal part. We insert new literal nodes before this so that the
-          // tree walker keeps its position correctly.
-          node.textContent = strings[lastIndex] || marker;
-
           // Generate a new text node for each literal section
           // These nodes are also used as the markers for node parts
           for (let i = 0; i < lastIndex; i++) {
-            parent.insertBefore(document.createTextNode(strings[i] || marker), node);
+            // IE doesn't clone empty text nodes, so use comments instead
+            parent.insertBefore(
+                strings[i] === '' ? document.createComment('') :
+                                    document.createTextNode(strings[i]),
+                node);
             this.parts.push(new TemplatePart('node', index++));
           }
+
+          parent.insertBefore(
+              strings[lastIndex] === '' ?
+                  document.createComment('') :
+                  document.createTextNode(strings[lastIndex]),
+              node);
+
+          nodesToRemove.push(node);
         } else {
           // Strip whitespace-only nodes, only between elements, or at the
           // beginning or end of elements.
@@ -300,7 +307,7 @@ export class Template {
         const previousSibling = node.previousSibling;
         if (previousSibling === null || previousSibling !== previousNode ||
             previousSibling.nodeType !== Node.TEXT_NODE) {
-          parent.insertBefore(document.createTextNode(marker), node);
+          parent.insertBefore(document.createComment(''), node);
         } else {
           index--;
         }
@@ -310,7 +317,7 @@ export class Template {
         // We don't have to check if the next node is going to be removed,
         // because that node will induce a new marker if so.
         if (node.nextSibling === null) {
-          parent.insertBefore(document.createTextNode(marker), node);
+          parent.insertBefore(document.createComment(''), node);
         } else {
           index--;
         }
@@ -432,14 +439,6 @@ export class NodePart implements SinglePart {
     this.instance = instance;
     this.startNode = startNode;
     this.endNode = endNode;
-
-    if (startNode.nodeValue === marker) {
-      startNode.nodeValue = '';
-    }
-
-    if (endNode.nodeValue === marker) {
-      endNode.nodeValue = '';
-    }
 
     this._previousValue = undefined;
   }

--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -37,7 +37,7 @@ suite('repeat', () => {
       render(r, container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
     });
 
     test('renders a list twice', () => {
@@ -48,12 +48,12 @@ suite('repeat', () => {
       render(t([1, 2, 3]), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
 
       render(t([1, 2, 3]), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
     });
 
     test('shuffles are stable', () => {
@@ -64,14 +64,14 @@ suite('repeat', () => {
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
       const children1 = Array.from(container.querySelectorAll('li'));
 
       items = [3, 2, 1];
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 3</li><li>item: 2</li><li>item: 1</li>`);
+          `<!----><li>item: 3<!----></li><li>item: 2<!----></li><li>item: 1<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[2]);
       assert.strictEqual(children1[1], children2[1]);
@@ -87,13 +87,13 @@ suite('repeat', () => {
 
       assert.equal(
           container.innerHTML,
-          [1, 2, 3, 4, 5].map((i) => `<li>item: ${i}</li>`).join(''));
+          `<!---->${[1, 2, 3, 4, 5].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
 
       render(t([1, 5, 3, 4, 2]), container);
 
       assert.equal(
           container.innerHTML,
-          [1, 5, 3, 4, 2].map((i) => `<li>item: ${i}</li>`).join(''));
+          `<!---->${[1, 5, 3, 4, 2].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
     });
 
     test('can re-render after swap', () => {
@@ -105,13 +105,13 @@ suite('repeat', () => {
 
       assert.equal(
           container.innerHTML,
-          [1, 2, 3].map((i) => `<li>item: ${i}</li>`).join(''));
+          `<!---->${[1, 2, 3].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
 
       render(t([3, 2, 1]), container);
 
       assert.equal(
           container.innerHTML,
-          [3, 2, 1].map((i) => `<li>item: ${i}</li>`).join(''));
+          `<!---->${[3, 2, 1].map((i) => `<li>item: ${i}<!----></li>`).join('')}<!---->`);
 
       render(t([3, 2, 1]), container);
     });
@@ -122,7 +122,7 @@ suite('repeat', () => {
           <li>item: ${i}</li>`)}`;
 
       render(t([666, 666]), container);
-      assert.equal(container.innerHTML, `<li>item: 666</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 666<!----></li><!---->`);
     });
 
     test('can render repeated items with skip', () => {
@@ -131,7 +131,7 @@ suite('repeat', () => {
           <li>item: ${i}</li>`)}`;
 
       render(t([666, 777, 666]), container);
-      assert.equal(container.innerHTML, `<li>item: 777</li><li>item: 666</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 777<!----></li><li>item: 666<!----></li><!---->`);
     });
 
     test('can rerender repeated items', () => {
@@ -142,7 +142,7 @@ suite('repeat', () => {
 
       render(t([666, 666]), container);
       assert.equal(updates, 2);
-      assert.equal(container.innerHTML, `<li>item: 2</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 2<!----></li><!---->`);
     });
 
     test('can insert an item at the beginning', () => {
@@ -156,7 +156,7 @@ suite('repeat', () => {
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 0</li><li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 0<!----></li><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
     });
 
     test('can insert an item at the end', () => {
@@ -170,7 +170,7 @@ suite('repeat', () => {
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li><li>item: 4</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><li>item: 4<!----></li><!---->`);
     });
 
     test('can replace with an empty list', () => {
@@ -182,7 +182,7 @@ suite('repeat', () => {
       render(t(), container);
       items = [];
       render(t(), container);
-      assert.equal(container.innerHTML, ``);
+      assert.equal(container.innerHTML, `<!----><!---->`);
     });
 
     test('can remove the first item', () => {
@@ -196,7 +196,7 @@ suite('repeat', () => {
 
       items = [2, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `<li>item: 2</li><li>item: 3</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[1], children2[0]);
       assert.strictEqual(children1[2], children2[1]);
@@ -213,7 +213,7 @@ suite('repeat', () => {
 
       items = [1, 2];
       render(t(), container);
-      assert.equal(container.innerHTML, `<li>item: 1</li><li>item: 2</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 1<!----></li><li>item: 2<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[0]);
       assert.strictEqual(children1[1], children2[1]);
@@ -230,7 +230,7 @@ suite('repeat', () => {
 
       items = [1, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `<li>item: 1</li><li>item: 3</li>`);
+      assert.equal(container.innerHTML, `<!----><li>item: 1<!----></li><li>item: 3<!----></li><!---->`);
       const children2 = Array.from(container.querySelectorAll('li'));
       assert.strictEqual(children1[0], children2[0]);
       assert.strictEqual(children1[2], children2[1]);
@@ -246,7 +246,7 @@ suite('repeat', () => {
       render(r, container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
     });
 
     test('shuffles a list', () => {
@@ -256,13 +256,13 @@ suite('repeat', () => {
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><!---->`);
 
       items = [3, 2, 1];
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 3</li><li>item: 2</li><li>item: 1</li>`);
+          `<!----><li>item: 3<!----></li><li>item: 2<!----></li><li>item: 1<!----></li><!---->`);
     });
 
     test('can replace with an empty list', () => {
@@ -273,7 +273,7 @@ suite('repeat', () => {
 
       items = [];
       render(t(), container);
-      assert.equal(container.innerHTML, ``);
+      assert.equal(container.innerHTML, `<!----><!---->`);
     });
 
     test('re-renders a list', () => {
@@ -285,7 +285,7 @@ suite('repeat', () => {
       render(t(), container);
       assert.equal(
           container.innerHTML,
-          `<li>item: 1</li><li>item: 2</li><li>item: 3</li><li>item: 4</li><li>item: 5</li>`);
+          `<!----><li>item: 1<!----></li><li>item: 2<!----></li><li>item: 3<!----></li><li>item: 4<!----></li><li>item: 5<!----></li><!---->`);
     });
   });
 });

--- a/src/test/lib/unsafe-html_test.ts
+++ b/src/test/lib/unsafe-html_test.ts
@@ -28,7 +28,7 @@ suite('unsafeHTML', () => {
         html`<div>before${unsafeHTML('<span>inner</span>after</div>')}`,
         container);
     assert.equal(
-        container.innerHTML, '<div>before<span>inner</span>after</div>');
+        container.innerHTML, '<div>before<span>inner</span>after<!----></div>');
   });
 
 });

--- a/src/test/lib/until_test.ts
+++ b/src/test/lib/until_test.ts
@@ -31,11 +31,11 @@ suite('until', () => {
     render(
         html`<div>${until(promise, html`<span>loading...</span>`)}</div>`,
         container);
-    assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
+    assert.equal(container.innerHTML, '<div><!----><span>loading...</span><!----></div>');
     resolve!('foo');
     return promise.then(() => new Promise((r) => setTimeout(() => r())))
         .then(() => {
-          assert.equal(container.innerHTML, '<div>foo</div>');
+          assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
         });
   });
 

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -119,7 +119,7 @@ suite('lit-html', () => {
       const container = document.createElement('div');
       const result = html`<div>${1} ${2}</div>`;
       render(result, container);
-      assert.equal(container.innerHTML, '<div>1 2</div>');
+      assert.equal(container.innerHTML, '<div><!---->1 2<!----></div>');
     });
 
     test('parses expressions for two child nodes of one element', () => {
@@ -144,9 +144,9 @@ suite('lit-html', () => {
       };
       render(ul(['a', 'b', 'c']), container);
       assert.equal(
-          container.innerHTML, '<ul><li>a</li><li>b</li><li>c</li></ul>');
+          container.innerHTML, '<ul><!----><li><!---->a<!----></li><li><!---->b<!----></li><li><!---->c<!----></li><!----></ul>');
       render(ul(['x', 'y']), container);
-      assert.equal(container.innerHTML, '<ul><li>x</li><li>y</li></ul>');
+      assert.equal(container.innerHTML, '<ul><!----><li><!---->x<!----></li><li><!---->y<!----></li><!----></ul>');
     });
 
     test('resists XSS attempt in node values', () => {
@@ -179,22 +179,22 @@ suite('lit-html', () => {
 
       test('renders a string', () => {
         render(html`<div>${'foo'}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
       });
 
       test('renders a number', () => {
         render(html`<div>${123}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(container.innerHTML, '<div><!---->123<!----></div>');
       });
 
       test('renders undefined', () => {
         render(html`<div>${undefined}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
       });
 
       test('renders null', () => {
         render(html`<div>${null}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
       });
 
       test('does not call a function bound to text', () => {
@@ -206,45 +206,45 @@ suite('lit-html', () => {
 
       test('renders arrays', () => {
         render(html`<div>${[1, 2, 3]}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(container.innerHTML, '<div><!---->123<!----></div>');
       });
 
       test('renders nested templates', () => {
         const partial = html`<h1>${'foo'}</h1>`;
         render(html`${partial}${'bar'}`, container);
-        assert.equal(container.innerHTML, '<h1>foo</h1>bar');
+        assert.equal(container.innerHTML, '<!----><h1><!---->foo<!----></h1><!---->bar<!---->');
       });
 
       test('renders parts with whitespace after them', () => {
         render(html`<div>${'foo'} </div>`, container);
-        assert.equal(container.innerHTML, '<div>foo </div>');
+        assert.equal(container.innerHTML, '<div><!---->foo </div>');
       });
 
       test('preserves whitespace between parts', () => {
         render(html`<div>${'foo'} ${'bar'}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo bar</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo bar<!----></div>');
       });
 
       test('renders nested templates within table content', () => {
         let table = html`<table>${html`<tr>${html`<td></td>`}</tr>`}</table>`;
         render(table, container);
-        assert.equal(container.innerHTML, '<table><tr><td></td></tr></table>');
+        assert.equal(container.innerHTML, '<table><!----><tr><!----><td></td><!----></tr><!----></table>');
 
         table = html`<tbody>${html`<tr></tr>`}</tbody>`;
         render(table, container);
-        assert.equal(container.innerHTML, '<tbody><tr></tr></tbody>');
+        assert.equal(container.innerHTML, '<tbody><!----><tr></tr><!----></tbody>');
 
         table = html`<table><tr></tr>${html`<tr></tr>`}</table>`;
         render(table, container);
         assert.equal(
             container.innerHTML,
-            '<table><tbody><tr></tr><tr></tr></tbody></table>');
+            '<table><tbody><tr></tr><!----><tr></tr><!----></tbody></table>');
 
         table = html`<table><tr><td></td>${html`<td></td>`}</tr></table>`;
         render(table, container);
         assert.equal(
             container.innerHTML,
-            '<table><tbody><tr><td></td><td></td></tr></tbody></table>');
+            '<table><tbody><tr><td></td><!----><td></td><!----></tr></tbody></table>');
 
         table = html`<table><tr><td></td>${html`<td></td>`}${
                                                              html`<td></td>`
@@ -252,7 +252,7 @@ suite('lit-html', () => {
         render(table, container);
         assert.equal(
             container.innerHTML,
-            '<table><tbody><tr><td></td><td></td><td></td></tr></tbody></table>');
+            '<table><tbody><tr><td></td><!----><td></td><!----><td></td><!----></tr></tbody></table>');
       });
 
       const testSkipSafari10_0 =
@@ -274,7 +274,7 @@ suite('lit-html', () => {
       test('values contain interpolated values', () => {
         const t = html`${'a'},${'b'},${'c'}`;
         render(t, container);
-        assert.equal(container.innerHTML, 'a,b,c');
+        assert.equal(container.innerHTML, '<!---->a,b,c<!---->');
       });
 
       // test('renders multiple nested templates', () => {
@@ -286,13 +286,13 @@ suite('lit-html', () => {
 
       test('renders arrays of nested templates', () => {
         render(html`<div>${[1, 2, 3].map((i) => html`${i}`)}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(container.innerHTML, '<div><!----><!---->1<!----><!---->2<!----><!---->3<!----><!----></div>');
       });
 
       test('renders an element', () => {
         const child = document.createElement('p');
         render(html`<div>${child}</div>`, container);
-        assert.equal(container.innerHTML, '<div><p></p></div>');
+        assert.equal(container.innerHTML, '<div><!----><p></p><!----></div>');
       });
 
       test('renders an array of elements', () => {
@@ -303,7 +303,7 @@ suite('lit-html', () => {
         ];
         render(html`<div>${children}</div>`, container);
         assert.equal(
-            container.innerHTML, '<div><p></p><a></a><span></span></div>');
+            container.innerHTML, '<div><!----><p></p><a></a><span></span><!----></div>');
       });
 
       test('renders to an attribute', () => {
@@ -358,7 +358,7 @@ suite('lit-html', () => {
           <div>${''}</div>
           <div foo=${'bar'}></div>
         `, container);
-        assert.equal(container.innerHTML, '<div></div><div foo="bar"></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div><div foo="bar"></div>');
       });
 
       test('renders to attributes with attribute-like values', () => {
@@ -387,13 +387,13 @@ suite('lit-html', () => {
 
       test('renders to an attribute before a node', () => {
         render(html`<div foo="${'bar'}">${'baz'}</div>`, container);
-        assert.equal(container.innerHTML, '<div foo="bar">baz</div>');
+        assert.equal(container.innerHTML, '<div foo="bar"><!---->baz<!----></div>');
       });
 
       test('renders to an attribute after a node', () => {
         render(html`<div>${'baz'}</div><div foo="${'bar'}"></div>`, container);
         assert.equal(
-            container.innerHTML, '<div>baz</div><div foo="bar"></div>');
+            container.innerHTML, '<div><!---->baz<!----></div><div foo="bar"></div>');
       });
 
       test('renders a Promise', () => {
@@ -402,10 +402,10 @@ suite('lit-html', () => {
           resolve = res;
         });
         render(html`<div>${promise}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
         resolve!('foo');
         return promise.then(() => {
-          assert.equal(container.innerHTML, '<div>foo</div>');
+          assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
         });
       });
 
@@ -416,7 +416,7 @@ suite('lit-html', () => {
           }
         };
         render(html`<div>${promise}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
       });
 
       test('renders racing Promises correctly', () => {
@@ -435,21 +435,21 @@ suite('lit-html', () => {
 
         // First render, first Promise, no value
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
 
         promise = promise2;
         // Second render, second Promise, still no value
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
 
         // Resolve the first Promise, should not update the container
         resolve1!('foo');
         return promise1.then(() => {
-          assert.equal(container.innerHTML, '<div></div>');
+          assert.equal(container.innerHTML, '<div><!----><!----></div>');
           // Resolve the second Promise, should update the container
           resolve2!('bar');
           return promise2.then(() => {
-            assert.equal(container.innerHTML, '<div>bar</div>');
+            assert.equal(container.innerHTML, '<div><!---->bar<!----></div>');
           });
         });
       });
@@ -478,7 +478,7 @@ suite('lit-html', () => {
             </div>`, container);
         assert.equal(container.innerHTML, `<div foo="bar">
               baz
-              <p>qux</p></div>`);
+              <p><!---->qux<!----></p></div>`);
       });
 
       test('renders SVG', () => {
@@ -500,17 +500,17 @@ suite('lit-html', () => {
         render(t, container);
         assert.equal(container.innerHTML, `<div>
             <!-- this is a comment -->
-            <h1 class="foo">title</h1><p>foo</p></div>`);
+            <h1 class="foo">title</h1><p><!---->foo<!----></p></div>`);
       });
 
       test('renders expressions with preceding elements', () => {
         render(html`<a>${'foo'}</a>${html`<h1>${'bar'}</h1>`}`, container);
-        assert.equal(container.innerHTML, '<a>foo</a><h1>bar</h1>');
+        assert.equal(container.innerHTML, '<a><!---->foo<!----></a><!----><h1><!---->bar<!----></h1><!---->');
 
         // This is nearly the same test case as above, but was causing a
         // different stack trace
         render(html`<a>${'foo'}</a>${'bar'}`, container);
-        assert.equal(container.innerHTML, '<a>foo</a>bar');
+        assert.equal(container.innerHTML, '<a><!---->foo<!----></a><!---->bar<!---->');
       });
 
     });
@@ -529,7 +529,7 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>aaa</div>');
+        assert.equal(container.innerHTML, '<div><!---->aaa<!----></div>');
         const text = container.firstChild!.childNodes[1] as Text;
         assert.equal(text.textContent, 'aaa');
 
@@ -538,11 +538,11 @@ suite('lit-html', () => {
         // persist through the next render with the same value.
         text.textContent = 'bbb';
         assert.equal(text.textContent, 'bbb');
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(container.innerHTML, '<div><!---->bbb<!----></div>');
 
         // Re-render with the same content, should be a no-op
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(container.innerHTML, '<div><!---->bbb<!----></div>');
         const text2 = container.firstChild!.childNodes[1] as Text;
 
         // The next node should be the same too
@@ -555,13 +555,13 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>aaa</div>');
+        assert.equal(container.innerHTML, '<div><!---->aaa<!----></div>');
         const div = container.firstChild as HTMLDivElement;
         assert.equal(div.tagName, 'DIV');
 
         foo = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(container.innerHTML, '<div><!---->bbb<!----></div>');
         const div2 = container.firstChild as HTMLDivElement;
         // check that only the part changed
         assert.equal(div, div2);
@@ -574,11 +574,11 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}${bar}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foobar</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!---->bar<!----></div>');
 
         foo = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbbbar</div>');
+        assert.equal(container.innerHTML, '<div><!---->bbb<!---->bar<!----></div>');
       });
 
       test('renders and updates attributes', () => {
@@ -612,25 +612,25 @@ suite('lit-html', () => {
         };
 
         render(t(true), container);
-        assert.equal(container.innerHTML, '<h1>foo</h1>baz');
+        assert.equal(container.innerHTML, '<!----><h1><!---->foo<!----></h1><!---->baz<!---->');
 
         foo = 'bbb';
         render(t(true), container);
-        assert.equal(container.innerHTML, '<h1>bbb</h1>baz');
+        assert.equal(container.innerHTML, '<!----><h1><!---->bbb<!----></h1><!---->baz<!---->');
 
         render(t(false), container);
-        assert.equal(container.innerHTML, '<h2>bar</h2>baz');
+        assert.equal(container.innerHTML, '<!----><h2><!---->bar<!----></h2><!---->baz<!---->');
       });
 
       test('updates arrays', () => {
         let items = [1, 2, 3];
         const t = () => html`<div>${items}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(container.innerHTML, '<div><!---->123<!----></div>');
 
         items = [3, 2, 1];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>321</div>');
+        assert.equal(container.innerHTML, '<div><!---->321<!----></div>');
       });
 
       test('updates arrays that shrink then grow', () => {
@@ -639,30 +639,30 @@ suite('lit-html', () => {
 
         items = [1, 2, 3];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(container.innerHTML, '<div><!---->123<!----></div>');
 
         items = [4];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>4</div>');
+        assert.equal(container.innerHTML, '<div><!---->4<!----></div>');
 
         items = [5, 6, 7];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>567</div>');
+        assert.equal(container.innerHTML, '<div><!---->567<!----></div>');
       });
 
       test('updates an element', () => {
         let child: any = document.createElement('p');
         const t = () => html`<div>${child}<div></div></div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><p></p><div></div></div>');
+        assert.equal(container.innerHTML, '<div><!----><p></p><div></div></div>');
 
         child = undefined;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><div></div></div>');
+        assert.equal(container.innerHTML, '<div><!----><div></div></div>');
 
         child = document.createTextNode('foo');
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo<div></div></div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<div></div></div>');
       });
 
       test('updates an array of elements', () => {
@@ -674,15 +674,15 @@ suite('lit-html', () => {
         const t = () => html`<div>${children}</div>`;
         render(t(), container);
         assert.equal(
-            container.innerHTML, '<div><p></p><a></a><span></span></div>');
+            container.innerHTML, '<div><!----><p></p><a></a><span></span><!----></div>');
 
         children = null;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<div><!----><!----></div>');
 
         children = document.createTextNode('foo');
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
       });
 
       test(
@@ -763,7 +763,7 @@ suite('lit-html', () => {
         const container = document.createElement('div');
         const t = html`${html`<div someProp="${123}"></div>`}`;
         render(t, container, partCallback);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(container.innerHTML, '<!----><div></div><!---->');
         assert.strictEqual((container.firstElementChild as any).someProp, 123);
       });
 
@@ -848,12 +848,12 @@ suite('lit-html', () => {
 
       test('accepts nested templates', () => {
         part.setValue(html`<h1>${'foo'}</h1>`);
-        assert.equal(container.innerHTML, '<h1>foo</h1>');
+        assert.equal(container.innerHTML, '<h1><!---->foo<!----></h1>');
       });
 
       test('accepts arrays of nested templates', () => {
         part.setValue([1, 2, 3].map((i) => html`${i}`));
-        assert.equal(container.innerHTML, '123');
+        assert.equal(container.innerHTML, '<!---->1<!----><!---->2<!----><!---->3<!---->');
       });
 
       test('accepts an array of elements', () => {
@@ -870,22 +870,22 @@ suite('lit-html', () => {
         let value: string|TemplateResult = 'foo';
         const t = () => html`<div>${value}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
 
         value = html`<span>bar</span>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><span>bar</span></div>');
+        assert.equal(container.innerHTML, '<div><!----><span>bar</span><!----></div>');
       });
 
       test('updates a complex value to a simple one', () => {
         let value: string|TemplateResult = html`<span>bar</span>`;
         const t = () => html`<div>${value}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><span>bar</span></div>');
+        assert.equal(container.innerHTML, '<div><!----><span>bar</span><!----></div>');
 
         value = 'foo';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(container.innerHTML, '<div><!---->foo<!----></div>');
       });
 
       test('updates when called multiple times with simple values', () => {
@@ -968,11 +968,11 @@ suite('lit-html', () => {
         const t = () => html`<p></p>${items}<a></a>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<p></p>123<a></a>');
+        assert.equal(container.innerHTML, '<p></p><!---->123<a></a>');
 
         items = [1, 2, 3, 4];
         render(t(), container);
-        assert.equal(container.innerHTML, '<p></p>1234<a></a>');
+        assert.equal(container.innerHTML, '<p></p><!---->1234<a></a>');
       });
 
       test(
@@ -981,12 +981,12 @@ suite('lit-html', () => {
             let value = 'foo';
             const r = () => html`<h1>${value}</h1>`;
             part.setValue(r());
-            assert.equal(container.innerHTML, '<h1>foo</h1>');
+            assert.equal(container.innerHTML, '<h1><!---->foo<!----></h1>');
             const originalH1 = container.querySelector('h1');
 
             value = 'bar';
             part.setValue(r());
-            assert.equal(container.innerHTML, '<h1>bar</h1>');
+            assert.equal(container.innerHTML, '<h1><!---->bar<!----></h1>');
             const newH1 = container.querySelector('h1');
             assert.strictEqual(newH1, originalH1);
           });
@@ -997,12 +997,12 @@ suite('lit-html', () => {
             let items = [1, 2, 3];
             const r = () => items.map((i) => html`<li>${i}</li>`);
             part.setValue(r());
-            assert.equal(container.innerHTML, '<li>1</li><li>2</li><li>3</li>');
+            assert.equal(container.innerHTML, '<li><!---->1<!----></li><li><!---->2<!----></li><li><!---->3<!----></li>');
             const originalLIs = Array.from(container.querySelectorAll('li'));
 
             items = [3, 2, 1];
             part.setValue(r());
-            assert.equal(container.innerHTML, '<li>3</li><li>2</li><li>1</li>');
+            assert.equal(container.innerHTML, '<li><!---->3<!----></li><li><!---->2<!----></li><li><!---->1<!----></li>');
             const newLIs = Array.from(container.querySelectorAll('li'));
             assert.deepEqual(newLIs, originalLIs);
           });


### PR DESCRIPTION
Empty text nodes aren't cloned by IE when using document.importNode.
Putting content in the text ensures that they will be cloned by IE.

This increases the number of passing tests on IE11 from 40 to 93.
One failure remains for table handling, a couple are due to a different ordering of attributes in IE and the other remaining failures are due to missing `Promise`, `Array.from`, `String#startsWith`.

Fixes #201 
This is an alternative to #143 

Open questions:

- The nodes need a unique content. Given that we already have a unique marker, I just reused that instead of creating another unique string. This might be confusing, so maybe for readability's sake it should be a separate string?
- An alternative to the unique string could be Unicode codepoint U+2060 "word joiner", which could be left after cloning rather than having to remove after every clone. I don't know enough about this codepoint to know what the impact is of replacing empty text nodes with nodes containing this character (i.e. are there cases where this behaves differently from an empty text node?), so I opted to not use it.

EDIT: added some open questions