### PR TITLE
Add #192 - File rendering directive

### DIFF
--- a/demo/render-file.html
+++ b/demo/render-file.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+  <script type="module" src="./render-file.js"></script>
+</head>
+<body>
+<lit-render-file></lit-render-file>
+</body>
+</html>

--- a/demo/render-file.js
+++ b/demo/render-file.js
@@ -1,0 +1,13 @@
+
+import {html, render} from '../lit-html.js';
+import {file} from '../lib/file.js';
+
+export class LitRenderFile extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({mode: 'open'});
+    render(html`${file('render-file.tpl', 'Loading...')}`, this.shadowRoot || this);
+  }
+}
+
+customElements.define('lit-render-file', LitRenderFile);

--- a/demo/render-file.tpl
+++ b/demo/render-file.tpl
@@ -1,0 +1,1 @@
+<h1>Hello file template!</h1>

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {directive, html, NodePart} from '../lit-html.js';
+
+/**
+ * Display `defaultContent` until `promise` resolves.
+ */
+export const file = (file: string, defaultContent: any) =>
+  directive((part: NodePart) => {
+    part.setValue(defaultContent);
+
+    fetch(file).then((res) => res.text())
+      .then((responseContent) => {
+        // Parse responded content
+        const template = document.createElement('div');
+        template.innerHTML = responseContent;
+        // Render it so it would resolve with a templateResult
+        part.setValue(html`${template.childNodes}`);
+      });
+  });

--- a/src/test/lib/file_test.ts
+++ b/src/test/lib/file_test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {file} from '../../lib/file.js';
+import {html, render} from '../../lit-html.js';
+
+const assert = chai.assert;
+
+suite('until', () => {
+
+  test('displays defaultContent immediately', () => {
+    const container = document.createElement('div');
+    let resolve: (v: any) => void;
+    const promise = new Promise((res, _) => {
+      resolve = res;
+    });
+    render(
+        html`<div>${file('some-template.tpl', html`<span>loading...</span>`)}</div>`,
+        container);
+    assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
+    resolve!('foo');
+    return promise.then(() => new Promise((r) => setTimeout(() => r())))
+        .then(() => {
+          assert.equal(container.innerHTML, '<div>foo</div>');
+        });
+  });
+
+});


### PR DESCRIPTION
So by adding this directive it opens the possibility to render a file as a template string, the general usage:

```javascript
// somewhere in script
render(html`${file('file.tpl', 'Loading...')}`, document.body);
```

```html
<!-- file.tpl -->
<p>Rendered content from file</p>
```