### PR TITLE
Fix IE tests depending on ES2015 features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,6 +1195,25 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
@@ -2885,12 +2904,6 @@
       "version": "2.0.0",
       "resolved": "http://35.185.235.147/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
-    "get-own-property-symbols": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/get-own-property-symbols/-/get-own-property-symbols-0.9.2.tgz",
-      "integrity": "sha1-ZOO1bn3BGsP4yx62um+zmlOtWVQ=",
       "dev": true
     },
     "get-stdin": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/mocha": "^2.2.41",
+    "@webcomponents/template": "^1.1.0",
+    "babel-polyfill": "^6.26.0",
     "chai": "^4.0.2",
     "mocha": "^3.4.2",
     "tslint": "^5.7.0",
@@ -38,9 +40,7 @@
     "typescript": "^2.4.1",
     "uglify-es": "^3.0.27",
     "wct-browser-legacy": "^0.0.1-pre.10",
-    "web-component-tester": "^6.3.0",
-    "@webcomponents/template": "^1.1.0",
-    "get-own-property-symbols": "^0.9.2"
+    "web-component-tester": "^6.3.0"
   },
   "typings": "lit-html.d.ts",
   "dependencies": {}

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -111,7 +111,7 @@ suite('lit-extended', () => {
 
     test('adds event listener functions, calls with right this value', () => {
       let thisValue;
-      let event;
+      let event: Event;
       const listener = function(this: any, e: any) {
         event = e;
         thisValue = this;
@@ -120,7 +120,13 @@ suite('lit-extended', () => {
       const div = container.firstChild as HTMLElement;
       div.click();
       assert.equal(thisValue, div);
-      assert.instanceOf(event, MouseEvent);
+
+      // MouseEvent is not a function in IE, so the event cannot be an instance of it
+      if (typeof MouseEvent === 'function') {
+        assert.instanceOf(event!, MouseEvent);
+      } else {
+        assert.isDefined((event! as MouseEvent).initMouseEvent);
+      }
     });
 
     test('adds event listener objects, calls with right this value', () => {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -448,7 +448,7 @@ suite('lit-html', () => {
           assert.equal(container.innerHTML, '<div></div>');
           // Resolve the second Promise, should update the container
           resolve2!('bar');
-          return promise1.then(() => {
+          return promise2.then(() => {
             assert.equal(container.innerHTML, '<div>bar</div>');
           });
         });

--- a/test/index-polyserve.html
+++ b/test/index-polyserve.html
@@ -8,8 +8,8 @@
     <script>
       mocha.setup('tdd');
     </script>
-    <script src="../node_modules/get-own-property-symbols/build/get-own-property-symbols.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>
     <div id="mocha"></div>

--- a/test/index.html
+++ b/test/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/get-own-property-symbols/build/get-own-property-symbols.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>
     <script type="module" src="./lit-html_test.js"></script>


### PR DESCRIPTION
This PR includes a "complete" ES2015 polyfill. Alternatively we could select individual polyfills for every ES2015+ feature we use.

This PR also fixes two small issues in the tests.

Together with #202 this fixes _all tests but one_ in IE. The one failing test is linked to the template polyfill table issue.

In the past I saw some tests failing on the sorting of attributes, but I don't see them anymore. This makes me doubt whether these failing tests I saw were from lit-html or my lit-html extension.

Linked to issue #210 