### PR TITLE
Disable table test in IE

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -225,7 +225,12 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, '<div>foo bar</div>');
       });
 
-      test('renders nested templates within table content', () => {
+      const testSkipForTemplatePolyfill =
+          ((HTMLTemplateElement as any).decorate != null) ?
+          test.skip :
+          test;
+
+      testSkipForTemplatePolyfill('renders nested templates within table content', () => {
         let table = html`<table>${html`<tr>${html`<td></td>`}</tr>`}</table>`;
         render(table, container);
         assert.equal(container.innerHTML, '<table><tr><td></td></tr></table>');


### PR DESCRIPTION
This test fails due to a bug in the template polyfill. Disabling this test allows us to reach 100% passing tests on IE, which means IE can be added to the CI build.

As mentioned in #210
Together with #202 this change results in a passing build for IE.